### PR TITLE
Added a force UTF-8 option to plugin encodings.

### DIFF
--- a/Mopy/bash/basher.py
+++ b/Mopy/bash/basher.py
@@ -11946,7 +11946,8 @@ class Settings_PluginEncodings(Link):
         'gbk': _(u'Chinese (Simplified)'),
         'big5': _(u'Chinese (Traditional)'),
         'cp1251': _(u'Russian'),
-        'cp932': _(u'Japanese'),
+        'cp932': _(u'Japanese (Shift_JIS)'),
+        'utf-8': _(u'UTF-8'),
         'cp1252': _(u'Western European (English, French, German, etc)'),
         }
     def __init__(self):


### PR DESCRIPTION
Because the plugin encoding is UTF-8 in Japanese Skyrim environment. MOJIBAKE when not set UTF-8 explicitly.
Oblivion, Fallout3, NV are cp932.
