### PR TITLE
Wduda issue 155

### DIFF
--- a/Mopy/bash/bosh.py
+++ b/Mopy/bash/bosh.py
@@ -7486,7 +7486,7 @@ class InstallerConverter(object):
             if len(errorLine) or regErrMatch(line):
                 errorLine.append(line)
             if maExtracting:
-                extracted = unicode(GPath(maExtracting.group(1).strip()), 'utf8')
+                extracted = GPath(maExtracting.group(1).strip())
                 if progress:
                     progress(index,srcInstaller.s+u'\n'+_(u'Extracting files...')+u'\n'+extracted.s)
                 if extracted.cext in readExts:


### PR DESCRIPTION
I reverted the changes to one line made by lojack5 on July 5th as those were not necessary and were causing a bug - extracted holds a GPath object not a string and does not have to be modified in that way.
GPath already stores the path in a Unicode Object.

This fixes issue 155.
