### PR TITLE
Fix the issue with Installer when loading archives that have attributeless files

### DIFF
--- a/Mopy/bash/bosh/__init__.py
+++ b/Mopy/bash/bosh/__init__.py
@@ -5394,7 +5394,9 @@ class InstallerArchive(Installer):
             if   key == u'Solid': self.isSolid = (value[0] == u'+')
             elif key == u'Path': _li.filepath = value.decode('utf8')
             elif key == u'Size': _li.size = int(value)
-            elif key == u'Attributes': _li.isdir = (value[0] == u'D')
+            elif key == u'Attributes':
+				if len(value) > 0: _li.isdir = (value[0] == u'D')
+				else: _li.isdir = False
             elif key == u'CRC' and value: _li.crc = int(value,16)
             elif key == u'Method':
                 if _li.filepath and not _li.isdir and _li.filepath != \
@@ -5524,7 +5526,10 @@ class InstallerArchive(Installer):
                 if key == u'Path':
                     filepath[0] = value.decode('utf8')
                 elif key == u'Attributes':
-                    text.append((u'%s' % filepath[0], (value[0] == u'D')))
+                    if len(value) is 0:
+                        text.append((u'%s' % filepath[0], False))
+                    else:
+                        text.append((u'%s' % filepath[0], (value[0] == u'D')))
                 elif key == u'Method':
                     filepath[0] = u''
             apath = dirs['installers'].join(archive)

--- a/Mopy/bash/bosh/__init__.py
+++ b/Mopy/bash/bosh/__init__.py
@@ -5396,7 +5396,9 @@ class InstallerArchive(Installer):
             elif key == u'Size': _li.size = int(value)
             elif key == u'Attributes':
 				if len(value) > 0: _li.isdir = (value[0] == u'D')
-				else: _li.isdir = False
+				else:
+					_li.isdir = False
+					print u'WARNING: A file in the archive has no attributes.'
             elif key == u'CRC' and value: _li.crc = int(value,16)
             elif key == u'Method':
                 if _li.filepath and not _li.isdir and _li.filepath != \


### PR DESCRIPTION


I know the istruction say to do not pull request and working on a separate branch on wrye-bash page, but I was not able in any way to create a branch. Access Forbidden.

So I make this way
Hope you don't mind utumno.
