### PR TITLE
#311: Double-click master to jump to plugin in mod list

### DIFF
--- a/Mopy/bash/basher/__init__.py
+++ b/Mopy/bash/basher/__init__.py
@@ -380,6 +380,10 @@ class MasterList(_ModsUIList):
     def OnItemSelected(self, event): event.Skip()
     def OnKeyUp(self, event): event.Skip()
 
+    def OnDClick(self, event):
+        BashFrame.modList.RefreshUI()
+        BashFrame.modList.SelectAndShowItem(self.data_store[self.mouse_index].name, deselectOthers=True)
+
     #--Set ModInfo
     def SetFileInfo(self,fileInfo):
         self.ClearSelected()


### PR DESCRIPTION
When you double-click on a master file in the masters list, that plugin will be selected in the mod list, and that plugin will also be focused in the mod details pane. Addresses #311.