### PR TITLE
Added explicit x64 support to installer and fixed several issues

### DIFF
--- a/scripts/build/installer/install.nsi
+++ b/scripts/build/installer/install.nsi
@@ -12,16 +12,21 @@
         ; Python version requires Python, wxPython, Python Comtypes and PyWin32.
         ${If} $PythonVersionInstall == $True
             ; Look for Python.
-            ReadRegStr $Python_Path HKLM "SOFTWARE\Wow6432Node\Python\PythonCore\2.7\InstallPath" ""
+
+            ; HKLM
+            ReadRegStr $Python_Path HKLM "SOFTWARE\Python\PythonCore\2.7\InstallPath" ""
             ${If} $Python_Path == $Empty
-                ReadRegStr $Python_Path HKLM "SOFTWARE\Python\PythonCore\2.7\InstallPath" ""
+                ReadRegStr $Python_Path HKLM "SOFTWARE\WOW6432Node\Python\PythonCore\2.7\InstallPath" ""
             ${EndIf}
-            ${If} $Python_Path == $Empty
-                ReadRegStr $Python_Path HKCU "SOFTWARE\Wow6432Node\Python\PythonCore\2.7\InstallPath" ""
-            ${EndIf}
+
+            ; HKCU
             ${If} $Python_Path == $Empty
                 ReadRegStr $Python_Path HKCU "SOFTWARE\Python\PythonCore\2.7\InstallPath" ""
             ${EndIf}
+            ${If} $Python_Path == $Empty
+                ReadRegStr $Python_Path HKCU "SOFTWARE\WOW6432Node\Python\PythonCore\2.7\InstallPath" ""
+            ${EndIf}
+
 
             ;Detect Python Components:
             ${If} $Python_Path != $Empty
@@ -41,14 +46,14 @@
                 ${EndIf}
 
                 ; Detect wxPython.
-                ReadRegStr $Python_wx HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\wxPython2.8-unicode-py27_is1" "DisplayVersion"
+                ReadRegStr $Python_wx HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\wxPython2.8-unicode-py27_is1" "DisplayVersion"
                 ${If} $Python_wx == $Empty
-                    ReadRegStr $Python_wx HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\wxPython2.8-unicode-py27_is1" "DisplayVersion"
+                    ReadRegStr $Python_wx HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\wxPython2.8-unicode-py27_is1" "DisplayVersion"
                 ${EndIf}
                 ; Detect PyWin32.
-                ReadRegStr $1         HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\pywin32-py2.7" "DisplayName"
+                ReadRegStr $1         HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\pywin32-py2.7" "DisplayName"
                 ${If} $1 == $Empty
-                    ReadRegStr $1         HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\pywin32-py2.7" "DisplayName"
+                    ReadRegStr $1         HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\pywin32-py2.7" "DisplayName"
                 ${EndIf}
                 StrCpy $Python_pywin32 $1 3 -3
 
@@ -189,15 +194,15 @@
         ${EndIf}
         ; Write the uninstall keys for Windows
         SetOutPath "$COMMONFILES\Wrye Bash"
-        WriteRegStr HKLM "Software\Wrye Bash" "Installer Path" "$EXEPATH"
-        WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash" "DisplayName" "Wrye Bash"
-        WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash" "UninstallString" '"$COMMONFILES\Wrye Bash\uninstall.exe"'
-        WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash" "URLInfoAbout" 'http://oblivion.nexusmods.com/mods/22368'
-        WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash" "HelpLink" 'http://forums.bethsoft.com/topic/1376871-rel-wrye-bash/'
-        WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash" "Publisher" 'Wrye & Wrye Bash Development Team'
-        WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash" "DisplayVersion" '${WB_FILEVERSION}'
-        WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash" "NoModify" 1
-        WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash" "NoRepair" 1
+        WriteRegStr HKLM "SOFTWARE\Wrye Bash" "Installer Path" "$EXEPATH"
+        WriteRegStr HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash" "DisplayName" "Wrye Bash"
+        WriteRegStr HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash" "UninstallString" '"$COMMONFILES\Wrye Bash\uninstall.exe"'
+        WriteRegStr HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash" "URLInfoAbout" 'http://oblivion.nexusmods.com/mods/22368'
+        WriteRegStr HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash" "HelpLink" 'http://forums.bethsoft.com/topic/1376871-rel-wrye-bash/'
+        WriteRegStr HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash" "Publisher" 'Wrye & Wrye Bash Development Team'
+        WriteRegStr HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash" "DisplayVersion" '${WB_FILEVERSION}'
+        WriteRegDWORD HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash" "NoModify" 1
+        WriteRegDWORD HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash" "NoRepair" 1
         CreateDirectory "$COMMONFILES\Wrye Bash"
         WriteUninstaller "$COMMONFILES\Wrye Bash\uninstall.exe"
     SectionEnd

--- a/scripts/build/installer/install.nsi
+++ b/scripts/build/installer/install.nsi
@@ -260,7 +260,7 @@
                 ${EndIf}
             ${EndIf}
         ${EndIf}
-        ${If} $Fallout4 == ${BST_CHECKED}
+        ${If} $CheckState_Fallout4 == ${BST_CHECKED}
             ${If} $Path_Fallout4 != $Empty
                 SetOutPath $Path_Fallout4\Mopy
                 ${If} $CheckState_Fallout4_Py == ${BST_CHECKED}
@@ -276,7 +276,7 @@
                 ${EndIf}
             ${EndIf}
         ${EndIf}
-        ${If} $SkyrimSE == ${BST_CHECKED}
+        ${If} $CheckState_SkyrimSE == ${BST_CHECKED}
             ${If} $Path_SkyrimSE != $Empty
                 SetOutPath $Path_SkyrimSE\Mopy
                 ${If} $CheckState_SkyrimSE_Py == ${BST_CHECKED}

--- a/scripts/build/installer/install.nsi
+++ b/scripts/build/installer/install.nsi
@@ -1,7 +1,6 @@
 ; install.nsi
 ; Installation script for Wrye Bash NSIS installer.
 
-
 ;-------------------------------- The Installation Sections:
 
     Section "Prerequisites" Prereq
@@ -11,22 +10,19 @@
 
         ; Python version requires Python, wxPython, Python Comtypes and PyWin32.
         ${If} $PythonVersionInstall == $True
-            ; Look for Python.
-
-            ; HKLM
+            ; Look for Python in HKLM
             ReadRegStr $Python_Path HKLM "SOFTWARE\Python\PythonCore\2.7\InstallPath" ""
             ${If} $Python_Path == $Empty
                 ReadRegStr $Python_Path HKLM "SOFTWARE\WOW6432Node\Python\PythonCore\2.7\InstallPath" ""
             ${EndIf}
 
-            ; HKCU
+            ; Look for Python in HKCU
             ${If} $Python_Path == $Empty
                 ReadRegStr $Python_Path HKCU "SOFTWARE\Python\PythonCore\2.7\InstallPath" ""
             ${EndIf}
             ${If} $Python_Path == $Empty
                 ReadRegStr $Python_Path HKCU "SOFTWARE\WOW6432Node\Python\PythonCore\2.7\InstallPath" ""
             ${EndIf}
-
 
             ;Detect Python Components:
             ${If} $Python_Path != $Empty
@@ -50,11 +46,13 @@
                 ${If} $Python_wx == $Empty
                     ReadRegStr $Python_wx HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\wxPython2.8-unicode-py27_is1" "DisplayVersion"
                 ${EndIf}
+
                 ; Detect PyWin32.
                 ReadRegStr $1         HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\pywin32-py2.7" "DisplayName"
                 ${If} $1 == $Empty
                     ReadRegStr $1         HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\pywin32-py2.7" "DisplayName"
                 ${EndIf}
+
                 StrCpy $Python_pywin32 $1 3 -3
 
                 ; Compare versions.
@@ -84,6 +82,7 @@
             ${Else}
                 DetailPrint "Python 2.7 is already installed; skipping!"
             ${EndIf}
+
             ${If} $Python_wx == "1"
                 SetOutPath "$TEMP\PythonInstallers"
                 DetailPrint "wxPython 2.8.12.1 - Downloading..."
@@ -104,6 +103,7 @@
             ${Else}
                 DetailPrint "wxPython 2.8.12.1 is already installed; skipping!"
             ${EndIf}
+
             ${If} $Python_Comtypes == "1"
                 SetOutPath "$TEMP\PythonInstallers"
                 DetailPrint "Comtypes 0.6.2 - Downloading..."
@@ -124,6 +124,7 @@
             ${Else}
                 DetailPrint "Comtypes 0.6.2 is already installed; skipping!"
             ${EndIf}
+
             ${If} $Python_pywin32 == "1"
                 SetOutPath "$TEMP\PythonInstallers"
                 DetailPrint "PyWin32 - Downloading..."
@@ -156,42 +157,49 @@
                 !insertmacro InstallBashFiles "Oblivion" "Oblivion" "$Path_OB" $Reg_Value_OB_Py $Reg_Value_OB_Exe "Oblivion Path" $CheckState_OB_Py $CheckState_OB_Exe true
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Nehrim == ${BST_CHECKED}
             ; Install resources:
             ${If} $Path_Nehrim != $Empty
                 !insertmacro InstallBashFiles "Nehrim" "Oblivion" "$Path_Nehrim" $Reg_Value_Nehrim_Py $Reg_Value_Nehrim_Exe "Nehrim Path" $CheckState_Nehrim_Py $CheckState_Nehrim_Exe true
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Skyrim == ${BST_CHECKED}
             ; Install resources:
             ${If} $Path_Skyrim != $Empty
                 !insertmacro InstallBashFiles "Skyrim" "Skyrim" "$Path_Skyrim" $Reg_Value_Skyrim_Py $Reg_Value_Skyrim_Exe "Skyrim Path" $CheckState_Skyrim_Py $CheckState_Skyrim_Exe false
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Fallout4 == ${BST_CHECKED}
             ; Install resources:
             ${If} $Path_Fallout4 != $Empty
                 !insertmacro InstallBashFiles "Fallout4" "Fallout4" "$Path_Fallout4" $Reg_Value_Fallout4_Py $Reg_Value_Fallout4_Exe "Fallout4 Path" $CheckState_Fallout4_Py $CheckState_Fallout4_Exe false
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_SkyrimSE == ${BST_CHECKED}
             ; Install resources:
             ${If} $Path_SkyrimSE != $Empty
                 !insertmacro InstallBashFiles "SkyrimSE" "SkyrimSE" "$Path_SkyrimSE" $Reg_Value_SkyrimSE_Py $Reg_Value_SkyrimSE_Exe "SkyrimSE Path" $CheckState_SkyrimSE_Py $CheckState_SkyrimSE_Exe false
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Ex1 == ${BST_CHECKED}
             ; Install resources:
             ${If} $Path_Ex1 != $Empty
                 !insertmacro InstallBashFiles "Extra Path 1" "" $Path_Ex1 $Reg_Value_Ex1_Py $Reg_Value_Ex1_Exe "Extra Path 1" $CheckState_Ex1_Py $CheckState_Ex1_Exe false
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Ex2 == ${BST_CHECKED}
             ; Install resources:
             ${If} $Path_Ex2 != $Empty
                 !insertmacro InstallBashFiles "Extra Path 2" "" $Path_Ex2 $Reg_Value_Ex2_Py $Reg_Value_Ex2_Exe "Extra Path 2" $CheckState_Ex2_Py $CheckState_Ex2_Exe false
             ${EndIf}
         ${EndIf}
+
         ; Write the uninstall keys for Windows
         SetOutPath "$COMMONFILES\Wrye Bash"
         WriteRegStr HKLM "SOFTWARE\Wrye Bash" "Installer Path" "$EXEPATH"
@@ -208,7 +216,6 @@
     SectionEnd
 
     Section "Start Menu Shortcuts" Shortcuts_SM
-
         CreateDirectory "$SMPROGRAMS\Wrye Bash"
         CreateShortCut "$SMPROGRAMS\Wrye Bash\Uninstall.lnk" "$COMMONFILES\Wrye Bash\uninstall.exe" "" "$COMMONFILES\Wrye Bash\uninstall.exe" 0
 
@@ -228,6 +235,7 @@
                 ${EndIf}
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Nehrim == ${BST_CHECKED}
             ${If} $Path_Nehrim != $Empty
                 SetOutPath $Path_Nehrim\Mopy
@@ -244,6 +252,7 @@
                 ${EndIf}
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Skyrim == ${BST_CHECKED}
             ${If} $Path_Skyrim != $Empty
                 SetOutPath $Path_Skyrim\Mopy
@@ -260,6 +269,7 @@
                 ${EndIf}
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Fallout4 == ${BST_CHECKED}
             ${If} $Path_Fallout4 != $Empty
                 SetOutPath $Path_Fallout4\Mopy
@@ -276,6 +286,7 @@
                 ${EndIf}
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_SkyrimSE == ${BST_CHECKED}
             ${If} $Path_SkyrimSE != $Empty
                 SetOutPath $Path_SkyrimSE\Mopy
@@ -292,6 +303,7 @@
                 ${EndIf}
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Ex1 == ${BST_CHECKED}
             ${If} $Path_Ex1 != $Empty
                 SetOutPath $Path_Ex1\Mopy
@@ -308,6 +320,7 @@
                 ${EndIf}
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Ex2 == ${BST_CHECKED}
             ${If} $Path_Ex2 != $Empty
                 SetOutPath $Path_Ex2\Mopy

--- a/scripts/build/installer/install.nsi
+++ b/scripts/build/installer/install.nsi
@@ -152,43 +152,43 @@
 
         ${If} $CheckState_OB == ${BST_CHECKED}
             ; Install resources:
-            ${If} Path_OB != $Empty
+            ${If} $Path_OB != $Empty
                 !insertmacro InstallBashFiles "Oblivion" "Oblivion" "$Path_OB" $Reg_Value_OB_Py $Reg_Value_OB_Exe "Oblivion Path" $CheckState_OB_Py $CheckState_OB_Exe true
             ${EndIf}
         ${EndIf}
         ${If} $CheckState_Nehrim == ${BST_CHECKED}
             ; Install resources:
-            ${If} Path_Nehrim != $Empty
+            ${If} $Path_Nehrim != $Empty
                 !insertmacro InstallBashFiles "Nehrim" "Oblivion" "$Path_Nehrim" $Reg_Value_Nehrim_Py $Reg_Value_Nehrim_Exe "Nehrim Path" $CheckState_Nehrim_Py $CheckState_Nehrim_Exe true
             ${EndIf}
         ${EndIf}
         ${If} $CheckState_Skyrim == ${BST_CHECKED}
             ; Install resources:
-            ${If} Path_Skyrim != $Empty
+            ${If} $Path_Skyrim != $Empty
                 !insertmacro InstallBashFiles "Skyrim" "Skyrim" "$Path_Skyrim" $Reg_Value_Skyrim_Py $Reg_Value_Skyrim_Exe "Skyrim Path" $CheckState_Skyrim_Py $CheckState_Skyrim_Exe false
             ${EndIf}
         ${EndIf}
         ${If} $CheckState_Fallout4 == ${BST_CHECKED}
             ; Install resources:
-            ${If} Path_Fallout4 != $Empty
+            ${If} $Path_Fallout4 != $Empty
                 !insertmacro InstallBashFiles "Fallout4" "Fallout4" "$Path_Fallout4" $Reg_Value_Fallout4_Py $Reg_Value_Fallout4_Exe "Fallout4 Path" $CheckState_Fallout4_Py $CheckState_Fallout4_Exe false
             ${EndIf}
         ${EndIf}
         ${If} $CheckState_SkyrimSE == ${BST_CHECKED}
             ; Install resources:
-            ${If} Path_SkyrimSE != $Empty
+            ${If} $Path_SkyrimSE != $Empty
                 !insertmacro InstallBashFiles "SkyrimSE" "SkyrimSE" "$Path_SkyrimSE" $Reg_Value_SkyrimSE_Py $Reg_Value_SkyrimSE_Exe "SkyrimSE Path" $CheckState_SkyrimSE_Py $CheckState_SkyrimSE_Exe false
             ${EndIf}
         ${EndIf}
         ${If} $CheckState_Ex1 == ${BST_CHECKED}
             ; Install resources:
-            ${If} Path_Ex1 != $Empty
+            ${If} $Path_Ex1 != $Empty
                 !insertmacro InstallBashFiles "Extra Path 1" "" $Path_Ex1 $Reg_Value_Ex1_Py $Reg_Value_Ex1_Exe "Extra Path 1" $CheckState_Ex1_Py $CheckState_Ex1_Exe false
             ${EndIf}
         ${EndIf}
         ${If} $CheckState_Ex2 == ${BST_CHECKED}
             ; Install resources:
-            ${If} Path_Ex2 != $Empty
+            ${If} $Path_Ex2 != $Empty
                 !insertmacro InstallBashFiles "Extra Path 2" "" $Path_Ex2 $Reg_Value_Ex2_Py $Reg_Value_Ex2_Exe "Extra Path 2" $CheckState_Ex2_Py $CheckState_Ex2_Exe false
             ${EndIf}
         ${EndIf}
@@ -213,7 +213,7 @@
         CreateShortCut "$SMPROGRAMS\Wrye Bash\Uninstall.lnk" "$COMMONFILES\Wrye Bash\uninstall.exe" "" "$COMMONFILES\Wrye Bash\uninstall.exe" 0
 
         ${If} $CheckState_OB == ${BST_CHECKED}
-            ${If} Path_OB != $Empty
+            ${If} $Path_OB != $Empty
                 SetOutPath $Path_OB\Mopy
                 ${If} $CheckState_OB_Py == ${BST_CHECKED}
                     CreateShortCut "$SMPROGRAMS\Wrye Bash\Wrye Bash - Oblivion.lnk" "$Path_OB\Mopy\Wrye Bash Launcher.pyw" "" "$Path_OB\Mopy\bash\images\bash_32.ico" 0
@@ -229,23 +229,23 @@
             ${EndIf}
         ${EndIf}
         ${If} $CheckState_Nehrim == ${BST_CHECKED}
-            ${If} Path_Nehrim != $Empty
+            ${If} $Path_Nehrim != $Empty
                 SetOutPath $Path_Nehrim\Mopy
                 ${If} $CheckState_Nehrim_Py == ${BST_CHECKED}
                     CreateShortCut "$SMPROGRAMS\Wrye Bash\Wrye Bash - Nehrim.lnk" "$Path_Nehrim\Mopy\Wrye Bash Launcher.pyw" "" "$Path_Nehrim\Mopy\bash\images\bash_32.ico" 0
                     CreateShortCut "$SMPROGRAMS\Wrye Bash\Wrye Bash - Nehrim (Debug Log).lnk" "$Path_Nehrim\Mopy\Wrye Bash Debug.bat" "" "$Path_Nehrim\Mopy\bash\images\bash_32.ico" 0
                     ${If} $CheckState_Nehrim_Exe == ${BST_CHECKED}
-                        CreateShortCut "$SMPROGRAMS\Wyre Bash\Wrye Bash (Standalone) - Nehrim.lnk" "$Path_Nehrim\Mopy\Wrye Bash.exe"
+                        CreateShortCut "$SMPROGRAMS\Wrye Bash\Wrye Bash (Standalone) - Nehrim.lnk" "$Path_Nehrim\Mopy\Wrye Bash.exe"
                         CreateShortCut "$SMPROGRAMS\Wrye Bash\Wrye Bash (Standalone) - Nehrim (Debug Log).lnk" "$Path_Nehrim\Mopy\Wrye Bash.exe" "-d"
                     ${EndIf}
                 ${ElseIf} $CheckState_Nehrim_Exe == ${BST_CHECKED}
-                    CreateShortCut "$SMPROGRAMS\Wyre Bash\Wrye Bash - Nehrim.lnk" "$Path_Nehrim\Mopy\Wrye Bash.exe"
-                    CreateShortCut "$SMPROGRAMS\Wyre Bash\Wrye Bash - Nehrim (Debug Log).lnk" "$Path_Nehrim\Mopy\Wrye Bash.exe" "-d"
+                    CreateShortCut "$SMPROGRAMS\Wrye Bash\Wrye Bash - Nehrim.lnk" "$Path_Nehrim\Mopy\Wrye Bash.exe"
+                    CreateShortCut "$SMPROGRAMS\Wrye Bash\Wrye Bash - Nehrim (Debug Log).lnk" "$Path_Nehrim\Mopy\Wrye Bash.exe" "-d"
                 ${EndIf}
             ${EndIf}
         ${EndIf}
         ${If} $CheckState_Skyrim == ${BST_CHECKED}
-            ${If} Path_Skyrim != $Empty
+            ${If} $Path_Skyrim != $Empty
                 SetOutPath $Path_Skyrim\Mopy
                 ${If} $CheckState_Skyrim_Py == ${BST_CHECKED}
                     CreateShortCut "$SMPROGRAMS\Wrye Bash\Wrye Bash - Skyrim.lnk" "$Path_Skyrim\Mopy\Wrye Bash Launcher.pyw" "" "$Path_Skyrim\Mopy\bash\images\bash_32.ico" 0
@@ -261,7 +261,7 @@
             ${EndIf}
         ${EndIf}
         ${If} $Fallout4 == ${BST_CHECKED}
-            ${If} Fallout4 != $Empty
+            ${If} $Path_Fallout4 != $Empty
                 SetOutPath $Path_Fallout4\Mopy
                 ${If} $CheckState_Fallout4_Py == ${BST_CHECKED}
                     CreateShortCut "$SMPROGRAMS\Wrye Bash\Wrye Bash - Fallout4.lnk" "$Path_Fallout4\Mopy\Wrye Bash Launcher.pyw" "" "$Path_Fallout4\Mopy\bash\images\bash_32.ico" 0
@@ -277,7 +277,7 @@
             ${EndIf}
         ${EndIf}
         ${If} $SkyrimSE == ${BST_CHECKED}
-            ${If} SkyrimSE != $Empty
+            ${If} $Path_SkyrimSE != $Empty
                 SetOutPath $Path_SkyrimSE\Mopy
                 ${If} $CheckState_SkyrimSE_Py == ${BST_CHECKED}
                     CreateShortCut "$SMPROGRAMS\Wrye Bash\Wrye Bash - SkyrimSE.lnk" "$Path_SkyrimSE\Mopy\Wrye Bash Launcher.pyw" "" "$Path_SkyrimSE\Mopy\bash\images\bash_32.ico" 0
@@ -293,7 +293,7 @@
             ${EndIf}
         ${EndIf}
         ${If} $CheckState_Ex1 == ${BST_CHECKED}
-            ${If} Path_Ex1 != $Empty
+            ${If} $Path_Ex1 != $Empty
                 SetOutPath $Path_Ex1\Mopy
                 ${If} $CheckState_Ex1_Py == ${BST_CHECKED}
                     CreateShortCut "$SMPROGRAMS\Wrye Bash\Wrye Bash - Extra 1.lnk" "$Path_Ex1\Mopy\Wrye Bash Launcher.pyw" "" "$Path_Ex1\Mopy\bash\images\bash_32.ico" 0
@@ -309,7 +309,7 @@
             ${EndIf}
         ${EndIf}
         ${If} $CheckState_Ex2 == ${BST_CHECKED}
-            ${If} Path_Ex2 != $Empty
+            ${If} $Path_Ex2 != $Empty
                 SetOutPath $Path_Ex2\Mopy
                 ${If} $CheckState_Ex2_Py == ${BST_CHECKED}
                     CreateShortCut "$SMPROGRAMS\Wrye Bash\Wrye Bash - Extra 2.lnk" "$Path_Ex2\Mopy\Wrye Bash Launcher.pyw" "" "$Path_Ex2\Mopy\bash\images\bash_32.ico" 0

--- a/scripts/build/installer/macros.nsh
+++ b/scripts/build/installer/macros.nsh
@@ -59,12 +59,19 @@
         ; Parameters:
         ;  GameName -  name of the game to remove registry entries for
 
+        ; handles x86 registry paths
         DeleteRegValue HKLM "SOFTWARE\Wrye Bash" "${GameName} Path"
         DeleteRegValue HKLM "SOFTWARE\Wrye Bash" "${GameName} Python Version"
         DeleteRegValue HKLM "SOFTWARE\Wrye Bash" "${GameName} Standalone Version"
+
+        ; handles x64 registry paths
         DeleteRegValue HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "${GameName} Path"
         DeleteRegValue HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "${GameName} Python Version"
         DeleteRegValue HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "${GameName} Standalone Version"
+
+        ; handles Extra Path 1 and Extra Path 2
+        DeleteRegValue HKLM "SOFTWARE\Wrye Bash" "${GameName}"
+        DeleteRegValue HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "${GameName}"
     !macroend
 
 
@@ -667,5 +674,150 @@
         !insertmacro RemoveOldFiles "${GamePath}"
         !insertmacro RemoveCurrentFiles "${GamePath}"
         !insertmacro RemoveRegistryEntries "${GameName}"
+    !macroend
+
+    !macro InitializeRegistryPaths
+        ReadRegStr $Path_OB HKLM "SOFTWARE\Wrye Bash" "Oblivion Path"
+        ${If} $Path_OB == $Empty
+            ReadRegStr $Path_OB HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Nehrim HKLM "SOFTWARE\Wrye Bash" "Nehrim Path"
+        ${If} $Path_Nehrim == $Empty
+            ReadRegStr $Path_Nehrim HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Skyrim HKLM "SOFTWARE\Wrye Bash" "Skyrim Path"
+        ${If} $Path_Skyrim == $Empty
+            ReadRegStr $Path_Skyrim HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\Wrye Bash" "Fallout4 Path"
+        ${If} $Path_Fallout4 == $Empty
+            ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Path"
+        ${EndIf}
+
+        ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Path"
+        ${If} $Path_SkyrimSE == $Empty
+            ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Ex1 HKLM "SOFTWARE\Wrye Bash" "Extra Path 1"
+        ${If} $Path_Ex1 == $Empty
+            ReadRegStr $Path_Ex1 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1"
+        ${EndIf}
+
+        ReadRegStr $Path_Ex2 HKLM "SOFTWARE\Wrye Bash" "Extra Path 2"
+        ${If} $Path_Ex2 == $Empty
+            ReadRegStr $Path_Ex2 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_OB_Py HKLM "SOFTWARE\Wrye Bash" "Oblivion Python Version"
+        ${If} $Reg_Value_OB_Py == $Empty
+            ReadRegStr $Reg_Value_OB_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Nehrim_Py HKLM "SOFTWARE\Wrye Bash" "Nehrim Python Version"
+        ${If} $Reg_Value_Nehrim_Py == $Empty
+            ReadRegStr $Reg_Value_Nehrim_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Skyrim_Py HKLM "SOFTWARE\Wrye Bash" "Skyrim Python Version"
+        ${If} $Reg_Value_Skyrim_Py == $Empty
+            ReadRegStr $Reg_Value_Skyrim_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Fallout4_Py HKLM "SOFTWARE\Wrye Bash" "Fallout4 Python Version"
+        ${If} $Reg_Value_Fallout4_Py == $Empty
+            ReadRegStr $Reg_Value_Fallout4_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_SkyrimSE_Py HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Python Version"
+        ${If} $Reg_Value_SkyrimSE_Py == $Empty
+            ReadRegStr $Reg_Value_SkyrimSE_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Ex1_Py HKLM "SOFTWARE\Wrye Bash" "Extra Path 1 Python Version"
+        ${If} $Reg_Value_Ex1_Py == $Empty
+            ReadRegStr $Reg_Value_Ex1_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1 Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Ex2_Py HKLM "SOFTWARE\Wrye Bash" "Extra Path 2 Python Version"
+        ${If} $Reg_Value_Ex2_Py == $Empty
+            ReadRegStr $Reg_Value_Ex2_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2 Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_OB_Exe HKLM "SOFTWARE\Wrye Bash" "Oblivion Standalone Version"
+        ${If} $Reg_Value_OB_Exe == $Empty
+            ReadRegStr $Reg_Value_OB_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Standalone Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Nehrim_Exe HKLM "SOFTWARE\Wrye Bash" "Nehrim Standalone Version"
+        ${If} $Reg_Value_Nehrim_Exe == $Empty
+            ReadRegStr $Reg_Value_Nehrim_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Standalone Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Skyrim_Exe HKLM "SOFTWARE\Wrye Bash" "Skyrim Standalone Version"
+        ${If} $Reg_Value_Skyrim_Exe == $Empty
+            ReadRegStr $Reg_Value_Skyrim_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Standalone Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Fallout4_Exe HKLM "SOFTWARE\Wrye Bash" "Fallout4 Standalone Version"
+        ${If} $Reg_Value_Fallout4_Exe == $Empty
+            ReadRegStr $Reg_Value_Fallout4_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Standalone Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_SkyrimSE_Exe HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Standalone Version"
+        ${If} $Reg_Value_SkyrimSE_Exe == $Empty
+            ReadRegStr $Reg_Value_SkyrimSE_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Standalone Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Ex1_Exe HKLM "SOFTWARE\Wrye Bash" "Extra Path 1 Standalone Version"
+        ${If} $Reg_Value_Ex1_Exe == $Empty
+            ReadRegStr $Reg_Value_Ex1_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1 Standalone Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Ex2_Exe HKLM "SOFTWARE\Wrye Bash" "Extra Path 2 Standalone Version"
+        ${If} $Reg_Value_Ex2_Exe == $Empty
+            ReadRegStr $Reg_Value_Ex2_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2 Standalone Version"
+        ${EndIf}
+    !macroend
+
+    !macro UpdateRegistryPaths
+        ; get current registry entries
+        ReadRegStr $Path_OB HKLM "SOFTWARE\Wrye Bash" "Oblivion Path"
+        ${If} $Path_OB == $Empty
+            ReadRegStr $Path_OB HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Nehrim HKLM "Software\Wrye Bash" "Nehrim Path"
+        ${If} $Path_Nehrim == $Empty
+            ReadRegStr $Path_Nehrim HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Skyrim HKLM "Software\Wrye Bash" "Skyrim Path"
+        ${If} $Path_Skyrim == $Empty
+            ReadRegStr $Path_Skyrim HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\Wrye Bash" "Fallout4 Path"
+        ${If} $Path_Fallout4 == $Empty
+            ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Path"
+        ${EndIf}
+
+        ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Path"
+        ${If} $Path_SkyrimSE == $Empty
+            ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Ex1 HKLM "SOFTWARE\Wrye Bash" "Extra Path 1"
+        ${If} $Path_Ex1 == $Empty
+            ReadRegStr $Path_Ex1 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1"
+        ${EndIf}
+
+        ReadRegStr $Path_Ex2 HKLM "SOFTWARE\Wrye Bash" "Extra Path 2"
+        ${If} $Path_Ex2 == $Empty
+            ReadRegStr $Path_Ex2 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2"
+        ${EndIf}
     !macroend
 !endif

--- a/scripts/build/installer/macros.nsh
+++ b/scripts/build/installer/macros.nsh
@@ -62,6 +62,9 @@
         DeleteRegValue HKLM "SOFTWARE\Wrye Bash" "${GameName} Path"
         DeleteRegValue HKLM "SOFTWARE\Wrye Bash" "${GameName} Python Version"
         DeleteRegValue HKLM "SOFTWARE\Wrye Bash" "${GameName} Standalone Version"
+        DeleteRegValue HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "${GameName} Path"
+        DeleteRegValue HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "${GameName} Python Version"
+        DeleteRegValue HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "${GameName} Standalone Version"
     !macroend
 
 

--- a/scripts/build/installer/main.nsi
+++ b/scripts/build/installer/main.nsi
@@ -30,7 +30,7 @@ Unicode true
     VIProductVersion ${WB_FILEVERSION}
     VIAddVersionKey /LANG=1033 "ProductName" "Wrye Bash"
     VIAddVersionKey /LANG=1033 "CompanyName" "Wrye Bash development team"
-    VIAddVersionKey /LANG=1033 "LegalCopyright" "� Wrye"
+    VIAddVersionKey /LANG=1033 "LegalCopyright" "© Wrye"
     VIAddVersionKey /LANG=1033 "FileDescription" "Installer for ${WB_NAME}"
     VIAddVersionKey /LANG=1033 "FileVersion" "${WB_FILEVERSION}"
     SetCompressor /SOLID lzma

--- a/scripts/build/installer/main.nsi
+++ b/scripts/build/installer/main.nsi
@@ -10,6 +10,7 @@ Unicode true
     !include "nsDialogs.nsh"
     !include "WordFunc.nsh"
     !include "StrFunc.nsh"
+    !include "macros.nsh"
     ; declare used functions
     ${StrLoc}
 
@@ -162,220 +163,14 @@ Unicode true
         StrCpy $Empty ""
         StrCpy $True "True"
 
-        ReadRegStr $Path_OB HKLM "SOFTWARE\Wrye Bash" "Oblivion Path"
-        ${If} $Path_OB == $Empty
-            ReadRegStr $Path_OB HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Path"
-        ${EndIf}
-
-        ReadRegStr $Path_Nehrim HKLM "SOFTWARE\Wrye Bash" "Nehrim Path"
-        ${If} $Path_Nehrim == $Empty
-            ReadRegStr $Path_Nehrim HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Path"
-        ${EndIf}
-
-        ReadRegStr $Path_Skyrim HKLM "SOFTWARE\Wrye Bash" "Skyrim Path"
-        ${If} $Path_Skyrim == $Empty
-            ReadRegStr $Path_Skyrim HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Path"
-        ${EndIf}
-
-        ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\Wrye Bash" "Fallout4 Path"
-        ${If} $Path_Fallout4 == $Empty
-            ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Path"
-        ${EndIf}
-
-        ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Path"
-        ${If} $Path_SkyrimSE == $Empty
-            ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Path"
-        ${EndIf}
-
-        ReadRegStr $Path_Ex1 HKLM "SOFTWARE\Wrye Bash" "Extra Path 1"
-        ${If} $Path_Ex1 == $Empty
-            ReadRegStr $Path_Ex1 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1"
-        ${EndIf}
-
-        ReadRegStr $Path_Ex2 HKLM "SOFTWARE\Wrye Bash" "Extra Path 2"
-        ${If} $Path_Ex2 == $Empty
-            ReadRegStr $Path_Ex2 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_OB_Py HKLM "SOFTWARE\Wrye Bash" "Oblivion Python Version"
-        ${If} $Reg_Value_OB_Py == $Empty
-            ReadRegStr $Reg_Value_OB_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Python Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Nehrim_Py HKLM "SOFTWARE\Wrye Bash" "Nehrim Python Version"
-        ${If} $Reg_Value_Nehrim_Py == $Empty
-            ReadRegStr $Reg_Value_Nehrim_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Python Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Skyrim_Py HKLM "SOFTWARE\Wrye Bash" "Skyrim Python Version"
-        ${If} $Reg_Value_Skyrim_Py == $Empty
-            ReadRegStr $Reg_Value_Skyrim_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Python Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Fallout4_Py HKLM "SOFTWARE\Wrye Bash" "Fallout4 Python Version"
-        ${If} $Reg_Value_Fallout4_Py == $Empty
-            ReadRegStr $Reg_Value_Fallout4_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Python Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_SkyrimSE_Py HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Python Version"
-        ${If} $Reg_Value_SkyrimSE_Py == $Empty
-            ReadRegStr $Reg_Value_SkyrimSE_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Python Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Ex1_Py HKLM "SOFTWARE\Wrye Bash" "Extra Path 1 Python Version"
-        ${If} $Reg_Value_Ex1_Py == $Empty
-            ReadRegStr $Reg_Value_Ex1_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1 Python Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Ex2_Py HKLM "SOFTWARE\Wrye Bash" "Extra Path 2 Python Version"
-        ${If} $Reg_Value_Ex2_Py == $Empty
-            ReadRegStr $Reg_Value_Ex2_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2 Python Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_OB_Exe HKLM "SOFTWARE\Wrye Bash" "Oblivion Standalone Version"
-        ${If} $Reg_Value_OB_Exe == $Empty
-            ReadRegStr $Reg_Value_OB_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Standalone Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Nehrim_Exe HKLM "SOFTWARE\Wrye Bash" "Nehrim Standalone Version"
-        ${If} $Reg_Value_Nehrim_Exe == $Empty
-            ReadRegStr $Reg_Value_Nehrim_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Standalone Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Skyrim_Exe HKLM "SOFTWARE\Wrye Bash" "Skyrim Standalone Version"
-        ${If} $Reg_Value_Skyrim_Exe == $Empty
-            ReadRegStr $Reg_Value_Skyrim_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Standalone Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Fallout4_Exe HKLM "SOFTWARE\Wrye Bash" "Fallout4 Standalone Version"
-        ${If} $Reg_Value_Fallout4_Exe == $Empty
-            ReadRegStr $Reg_Value_Fallout4_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Standalone Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_SkyrimSE_Exe HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Standalone Version"
-        ${If} $Reg_Value_SkyrimSE_Exe == $Empty
-            ReadRegStr $Reg_Value_SkyrimSE_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Standalone Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Ex1_Exe HKLM "SOFTWARE\Wrye Bash" "Extra Path 1 Standalone Version"
-        ${If} $Reg_Value_Ex1_Exe == $Empty
-            ReadRegStr $Reg_Value_Ex1_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1 Standalone Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Ex2_Exe HKLM "SOFTWARE\Wrye Bash" "Extra Path 2 Standalone Version"
-        ${If} $Reg_Value_Ex2_Exe == $Empty
-            ReadRegStr $Reg_Value_Ex2_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2 Standalone Version"
-        ${EndIf}
+        !insertmacro InitializeRegistryPaths
     FunctionEnd
 
     Function .onInit
         StrCpy $Empty ""
         StrCpy $True "True"
 
-        ReadRegStr $Path_OB HKLM "SOFTWARE\Wrye Bash" "Oblivion Path"
-        ${If} $Path_OB == $Empty
-            ReadRegStr $Path_OB HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Path"
-        ${EndIf}
-
-        ReadRegStr $Path_Nehrim HKLM "SOFTWARE\Wrye Bash" "Nehrim Path"
-        ${If} $Path_Nehrim == $Empty
-            ReadRegStr $Path_Nehrim HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Path"
-        ${EndIf}
-
-        ReadRegStr $Path_Skyrim HKLM "SOFTWARE\Wrye Bash" "Skyrim Path"
-        ${If} $Path_Skyrim == $Empty
-            ReadRegStr $Path_Skyrim HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Path"
-        ${EndIf}
-
-        ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\Wrye Bash" "Fallout4 Path"
-        ${If} $Path_Fallout4 == $Empty
-            ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Path"
-        ${EndIf}
-
-        ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Path"
-        ${If} $Path_SkyrimSE == $Empty
-            ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Path"
-        ${EndIf}
-
-        ReadRegStr $Path_Ex1 HKLM "SOFTWARE\Wrye Bash" "Extra Path 1"
-        ${If} $Path_Ex1 == $Empty
-            ReadRegStr $Path_Ex1 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1"
-        ${EndIf}
-
-        ReadRegStr $Path_Ex2 HKLM "SOFTWARE\Wrye Bash" "Extra Path 2"
-        ${If} $Path_Ex2 == $Empty
-            ReadRegStr $Path_Ex2 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_OB_Py HKLM "SOFTWARE\Wrye Bash" "Oblivion Python Version"
-        ${If} $Reg_Value_OB_Py == $Empty
-            ReadRegStr $Reg_Value_OB_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Python Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Nehrim_Py HKLM "SOFTWARE\Wrye Bash" "Nehrim Python Version"
-        ${If} $Reg_Value_Nehrim_Py == $Empty
-            ReadRegStr $Reg_Value_Nehrim_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Python Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Skyrim_Py HKLM "SOFTWARE\Wrye Bash" "Skyrim Python Version"
-        ${If} $Reg_Value_Skyrim_Py == $Empty
-            ReadRegStr $Reg_Value_Skyrim_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Python Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Fallout4_Py HKLM "SOFTWARE\Wrye Bash" "Fallout4 Python Version"
-        ${If} $Reg_Value_Fallout4_Py == $Empty
-            ReadRegStr $Reg_Value_Fallout4_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Python Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_SkyrimSE_Py HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Python Version"
-        ${If} $Reg_Value_SkyrimSE_Py == $Empty
-            ReadRegStr $Reg_Value_SkyrimSE_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Python Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Ex1_Py HKLM "SOFTWARE\Wrye Bash" "Extra Path 1 Python Version"
-        ${If} $Reg_Value_Ex1_Py == $Empty
-            ReadRegStr $Reg_Value_Ex1_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1 Python Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Ex2_Py HKLM "SOFTWARE\Wrye Bash" "Extra Path 2 Python Version"
-        ${If} $Reg_Value_Ex2_Py == $Empty
-            ReadRegStr $Reg_Value_Ex2_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2 Python Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_OB_Exe HKLM "SOFTWARE\Wrye Bash" "Oblivion Standalone Version"
-        ${If} $Reg_Value_OB_Exe == $Empty
-            ReadRegStr $Reg_Value_OB_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Standalone Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Nehrim_Exe HKLM "SOFTWARE\Wrye Bash" "Nehrim Standalone Version"
-        ${If} $Reg_Value_Nehrim_Exe == $Empty
-            ReadRegStr $Reg_Value_Nehrim_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Standalone Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Skyrim_Exe HKLM "SOFTWARE\Wrye Bash" "Skyrim Standalone Version"
-        ${If} $Reg_Value_Skyrim_Exe == $Empty
-            ReadRegStr $Reg_Value_Skyrim_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Standalone Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Fallout4_Exe HKLM "SOFTWARE\Wrye Bash" "Fallout4 Standalone Version"
-        ${If} $Reg_Value_Fallout4_Exe == $Empty
-            ReadRegStr $Reg_Value_Fallout4_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Standalone Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_SkyrimSE_Exe HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Standalone Version"
-        ${If} $Reg_Value_SkyrimSE_Exe == $Empty
-            ReadRegStr $Reg_Value_SkyrimSE_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Standalone Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Ex1_Exe HKLM "SOFTWARE\Wrye Bash" "Extra Path 1 Standalone Version"
-        ${If} $Reg_Value_Ex1_Exe == $Empty
-            ReadRegStr $Reg_Value_Ex1_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1 Standalone Version"
-        ${EndIf}
-
-        ReadRegStr $Reg_Value_Ex2_Exe HKLM "SOFTWARE\Wrye Bash" "Extra Path 2 Standalone Version"
-        ${If} $Reg_Value_Ex2_Exe == $Empty
-            ReadRegStr $Reg_Value_Ex2_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2 Standalone Version"
-        ${EndIf}
+        !insertmacro InitializeRegistryPaths
 
         StrCpy $MinVersion_Comtypes '0.6.2'
         StrCpy $MinVersion_wx '2.8.12'
@@ -586,7 +381,6 @@ Unicode true
 
 ;-------------------------------- Include Local Script Files
 
-    !include "macros.nsh"
     !include "pages.nsi"
     !include "install.nsi"
     !include "uninstall.nsi"

--- a/scripts/build/installer/main.nsi
+++ b/scripts/build/installer/main.nsi
@@ -30,7 +30,7 @@ Unicode true
     VIProductVersion ${WB_FILEVERSION}
     VIAddVersionKey /LANG=1033 "ProductName" "Wrye Bash"
     VIAddVersionKey /LANG=1033 "CompanyName" "Wrye Bash development team"
-    VIAddVersionKey /LANG=1033 "LegalCopyright" "© Wrye"
+    VIAddVersionKey /LANG=1033 "LegalCopyright" "ï¿½ Wrye"
     VIAddVersionKey /LANG=1033 "FileDescription" "Installer for ${WB_NAME}"
     VIAddVersionKey /LANG=1033 "FileVersion" "${WB_FILEVERSION}"
     SetCompressor /SOLID lzma
@@ -217,9 +217,9 @@ Unicode true
         StrCpy $Python_pywin32 "1"
 
         ${If} $Path_OB == $Empty
-            ReadRegStr $Path_OB HKLM "Software\Bethesda Softworks\Oblivion" "Installed Path"
+            ReadRegStr $Path_OB HKLM "SOFTWARE\Bethesda Softworks\Oblivion" "Installed Path"
             ${If} $Path_OB == $Empty
-                ReadRegStr $Path_OB HKLM "SOFTWARE\Wow6432Node\Bethesda Softworks\Oblivion" "Installed Path"
+                ReadRegStr $Path_OB HKLM "SOFTWARE\WOW6432Node\Bethesda Softworks\Oblivion" "Installed Path"
             ${EndIf}
         ${EndIf}
         ${If} $Path_OB != $Empty
@@ -234,9 +234,9 @@ Unicode true
         ${EndIf}
 
         ${If} $Path_Skyrim == $Empty
-            ReadRegStr $Path_Skyrim HKLM "Software\Bethesda Softworks\Skyrim" "Installed Path"
+            ReadRegStr $Path_Skyrim HKLM "SOFTWARE\Bethesda Softworks\Skyrim" "Installed Path"
             ${If} $Path_Skyrim == $Empty
-                ReadRegStr $Path_Skyrim HKLM "SOFTWARE\Wow6432Node\Bethesda Softworks\Skyrim" "Installed Path"
+                ReadRegStr $Path_Skyrim HKLM "SOFTWARE\WOW6432Node\Bethesda Softworks\Skyrim" "Installed Path"
             ${EndIf}
         ${EndIf}
         ${If} $Path_Skyrim != $Empty
@@ -244,9 +244,9 @@ Unicode true
         ${EndIf}
 
         ${If} $Path_Fallout4 == $Empty
-            ReadRegStr $Path_Fallout4 HKLM "Software\Bethesda Softworks\Fallout4" "Installed Path"
+            ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\Bethesda Softworks\Fallout4" "Installed Path"
             ${If} $Path_Fallout4 == $Empty
-                ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\Wow6432Node\Bethesda Softworks\Fallout4" "Installed Path"
+                ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\WOW6432Node\Bethesda Softworks\Fallout4" "Installed Path"
             ${EndIf}
         ${EndIf}
         ${If} $Path_Fallout4 != $Empty
@@ -254,9 +254,9 @@ Unicode true
         ${EndIf}
 
         ${If} $Path_SkyrimSE == $Empty
-            ReadRegStr $Path_SkyrimSE HKLM "Software\Bethesda Softworks\Skyrim Special Edition" "Installed Path"
+            ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\Bethesda Softworks\Skyrim Special Edition" "Installed Path"
             ${If} $Path_SkyrimSE == $Empty
-                ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\Wow6432Node\Bethesda Softworks\Skyrim Special Edition" "Installed Path"
+                ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\WOW6432Node\Bethesda Softworks\Skyrim Special Edition" "Installed Path"
             ${EndIf}
         ${EndIf}
         ${If} $Path_SkyrimSE != $Empty

--- a/scripts/build/installer/main.nsi
+++ b/scripts/build/installer/main.nsi
@@ -162,89 +162,89 @@ Unicode true
         StrCpy $Empty ""
         StrCpy $True "True"
 
-        ReadRegStr $Path_OB                HKLM "SOFTWARE\Wrye Bash" "Oblivion Path"
+        ReadRegStr $Path_OB HKLM "SOFTWARE\Wrye Bash" "Oblivion Path"
         ${If} $Path_OB == $Empty
-            ReadRegStr $Path_OB                HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Path"
+            ReadRegStr $Path_OB HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Path"
         ${EndIf}
 
-        ReadRegStr $Path_Nehrim            HKLM "SOFTWARE\Wrye Bash" "Nehrim Path"
+        ReadRegStr $Path_Nehrim HKLM "SOFTWARE\Wrye Bash" "Nehrim Path"
         ${If} $Path_Nehrim == $Empty
-            ReadRegStr $Path_Nehrim            HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Path"
+            ReadRegStr $Path_Nehrim HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Path"
         ${EndIf}
 
-        ReadRegStr $Path_Skyrim            HKLM "SOFTWARE\Wrye Bash" "Skyrim Path"
+        ReadRegStr $Path_Skyrim HKLM "SOFTWARE\Wrye Bash" "Skyrim Path"
         ${If} $Path_Skyrim == $Empty
-            ReadRegStr $Path_Skyrim            HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Path"
+            ReadRegStr $Path_Skyrim HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Path"
         ${EndIf}
 
-        ReadRegStr $Path_Fallout4          HKLM "SOFTWARE\Wrye Bash" "Fallout4 Path"
+        ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\Wrye Bash" "Fallout4 Path"
         ${If} $Path_Fallout4 == $Empty
-            ReadRegStr $Path_Fallout4          HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Path"
+            ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Path"
         ${EndIf}
 
-        ReadRegStr $Path_SkyrimSE          HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Path"
+        ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Path"
         ${If} $Path_SkyrimSE == $Empty
-            ReadRegStr $Path_SkyrimSE          HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Path"
+            ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Path"
         ${EndIf}
 
-        ReadRegStr $Path_Ex1               HKLM "SOFTWARE\Wrye Bash" "Extra Path 1"
+        ReadRegStr $Path_Ex1 HKLM "SOFTWARE\Wrye Bash" "Extra Path 1"
         ${If} $Path_Ex1 == $Empty
-            ReadRegStr $Path_Ex1               HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1"
+            ReadRegStr $Path_Ex1 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1"
         ${EndIf}
 
-        ReadRegStr $Path_Ex2               HKLM "SOFTWARE\Wrye Bash" "Extra Path 2"
+        ReadRegStr $Path_Ex2 HKLM "SOFTWARE\Wrye Bash" "Extra Path 2"
         ${If} $Path_Ex2 == $Empty
-            ReadRegStr $Path_Ex2               HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2"
+            ReadRegStr $Path_Ex2 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_OB_Py        HKLM "SOFTWARE\Wrye Bash" "Oblivion Python Version"
+        ReadRegStr $Reg_Value_OB_Py HKLM "SOFTWARE\Wrye Bash" "Oblivion Python Version"
         ${If} $Reg_Value_OB_Py == $Empty
-            ReadRegStr $Reg_Value_OB_Py        HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Python Version"
+            ReadRegStr $Reg_Value_OB_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Python Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_Nehrim_Py    HKLM "SOFTWARE\Wrye Bash" "Nehrim Python Version"
+        ReadRegStr $Reg_Value_Nehrim_Py HKLM "SOFTWARE\Wrye Bash" "Nehrim Python Version"
         ${If} $Reg_Value_Nehrim_Py == $Empty
-            ReadRegStr $Reg_Value_Nehrim_Py    HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Python Version"
+            ReadRegStr $Reg_Value_Nehrim_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Python Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_Skyrim_Py    HKLM "SOFTWARE\Wrye Bash" "Skyrim Python Version"
+        ReadRegStr $Reg_Value_Skyrim_Py HKLM "SOFTWARE\Wrye Bash" "Skyrim Python Version"
         ${If} $Reg_Value_Skyrim_Py == $Empty
-            ReadRegStr $Reg_Value_Skyrim_Py    HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Python Version"
+            ReadRegStr $Reg_Value_Skyrim_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Python Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_Fallout4_Py  HKLM "SOFTWARE\Wrye Bash" "Fallout4 Python Version"
+        ReadRegStr $Reg_Value_Fallout4_Py HKLM "SOFTWARE\Wrye Bash" "Fallout4 Python Version"
         ${If} $Reg_Value_Fallout4_Py == $Empty
-            ReadRegStr $Reg_Value_Fallout4_Py  HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Python Version"
+            ReadRegStr $Reg_Value_Fallout4_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Python Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_SkyrimSE_Py  HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Python Version"
+        ReadRegStr $Reg_Value_SkyrimSE_Py HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Python Version"
         ${If} $Reg_Value_SkyrimSE_Py == $Empty
-            ReadRegStr $Reg_Value_SkyrimSE_Py  HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Python Version"
+            ReadRegStr $Reg_Value_SkyrimSE_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Python Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_Ex1_Py       HKLM "SOFTWARE\Wrye Bash" "Extra Path 1 Python Version"
+        ReadRegStr $Reg_Value_Ex1_Py HKLM "SOFTWARE\Wrye Bash" "Extra Path 1 Python Version"
         ${If} $Reg_Value_Ex1_Py == $Empty
-            ReadRegStr $Reg_Value_Ex1_Py       HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1 Python Version"
+            ReadRegStr $Reg_Value_Ex1_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1 Python Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_Ex2_Py       HKLM "SOFTWARE\Wrye Bash" "Extra Path 2 Python Version"
+        ReadRegStr $Reg_Value_Ex2_Py HKLM "SOFTWARE\Wrye Bash" "Extra Path 2 Python Version"
         ${If} $Reg_Value_Ex2_Py == $Empty
-            ReadRegStr $Reg_Value_Ex2_Py       HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2 Python Version"
+            ReadRegStr $Reg_Value_Ex2_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2 Python Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_OB_Exe       HKLM "SOFTWARE\Wrye Bash" "Oblivion Standalone Version"
+        ReadRegStr $Reg_Value_OB_Exe HKLM "SOFTWARE\Wrye Bash" "Oblivion Standalone Version"
         ${If} $Reg_Value_OB_Exe == $Empty
-            ReadRegStr $Reg_Value_OB_Exe       HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Standalone Version"
+            ReadRegStr $Reg_Value_OB_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Standalone Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_Nehrim_Exe   HKLM "SOFTWARE\Wrye Bash" "Nehrim Standalone Version"
+        ReadRegStr $Reg_Value_Nehrim_Exe HKLM "SOFTWARE\Wrye Bash" "Nehrim Standalone Version"
         ${If} $Reg_Value_Nehrim_Exe == $Empty
-            ReadRegStr $Reg_Value_Nehrim_Exe   HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Standalone Version"
+            ReadRegStr $Reg_Value_Nehrim_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Standalone Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_Skyrim_Exe   HKLM "SOFTWARE\Wrye Bash" "Skyrim Standalone Version"
+        ReadRegStr $Reg_Value_Skyrim_Exe HKLM "SOFTWARE\Wrye Bash" "Skyrim Standalone Version"
         ${If} $Reg_Value_Skyrim_Exe == $Empty
-            ReadRegStr $Reg_Value_Skyrim_Exe   HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Standalone Version"
+            ReadRegStr $Reg_Value_Skyrim_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Standalone Version"
         ${EndIf}
 
         ReadRegStr $Reg_Value_Fallout4_Exe HKLM "SOFTWARE\Wrye Bash" "Fallout4 Standalone Version"
@@ -257,14 +257,14 @@ Unicode true
             ReadRegStr $Reg_Value_SkyrimSE_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Standalone Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_Ex1_Exe      HKLM "SOFTWARE\Wrye Bash" "Extra Path 1 Standalone Version"
+        ReadRegStr $Reg_Value_Ex1_Exe HKLM "SOFTWARE\Wrye Bash" "Extra Path 1 Standalone Version"
         ${If} $Reg_Value_Ex1_Exe == $Empty
-            ReadRegStr $Reg_Value_Ex1_Exe      HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1 Standalone Version"
+            ReadRegStr $Reg_Value_Ex1_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1 Standalone Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_Ex2_Exe      HKLM "SOFTWARE\Wrye Bash" "Extra Path 2 Standalone Version"
+        ReadRegStr $Reg_Value_Ex2_Exe HKLM "SOFTWARE\Wrye Bash" "Extra Path 2 Standalone Version"
         ${If} $Reg_Value_Ex2_Exe == $Empty
-            ReadRegStr $Reg_Value_Ex2_Exe      HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2 Standalone Version"
+            ReadRegStr $Reg_Value_Ex2_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2 Standalone Version"
         ${EndIf}
     FunctionEnd
 
@@ -272,89 +272,89 @@ Unicode true
         StrCpy $Empty ""
         StrCpy $True "True"
 
-        ReadRegStr $Path_OB                HKLM "SOFTWARE\Wrye Bash" "Oblivion Path"
+        ReadRegStr $Path_OB HKLM "SOFTWARE\Wrye Bash" "Oblivion Path"
         ${If} $Path_OB == $Empty
-            ReadRegStr $Path_OB                HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Path"
+            ReadRegStr $Path_OB HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Path"
         ${EndIf}
 
-        ReadRegStr $Path_Nehrim            HKLM "SOFTWARE\Wrye Bash" "Nehrim Path"
+        ReadRegStr $Path_Nehrim HKLM "SOFTWARE\Wrye Bash" "Nehrim Path"
         ${If} $Path_Nehrim == $Empty
-            ReadRegStr $Path_Nehrim            HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Path"
+            ReadRegStr $Path_Nehrim HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Path"
         ${EndIf}
 
-        ReadRegStr $Path_Skyrim            HKLM "SOFTWARE\Wrye Bash" "Skyrim Path"
+        ReadRegStr $Path_Skyrim HKLM "SOFTWARE\Wrye Bash" "Skyrim Path"
         ${If} $Path_Skyrim == $Empty
-            ReadRegStr $Path_Skyrim            HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Path"
+            ReadRegStr $Path_Skyrim HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Path"
         ${EndIf}
 
-        ReadRegStr $Path_Fallout4          HKLM "SOFTWARE\Wrye Bash" "Fallout4 Path"
+        ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\Wrye Bash" "Fallout4 Path"
         ${If} $Path_Fallout4 == $Empty
-            ReadRegStr $Path_Fallout4          HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Path"
+            ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Path"
         ${EndIf}
 
-        ReadRegStr $Path_SkyrimSE          HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Path"
+        ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Path"
         ${If} $Path_SkyrimSE == $Empty
-            ReadRegStr $Path_SkyrimSE          HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Path"
+            ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Path"
         ${EndIf}
 
-        ReadRegStr $Path_Ex1               HKLM "SOFTWARE\Wrye Bash" "Extra Path 1"
+        ReadRegStr $Path_Ex1 HKLM "SOFTWARE\Wrye Bash" "Extra Path 1"
         ${If} $Path_Ex1 == $Empty
-            ReadRegStr $Path_Ex1               HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1"
+            ReadRegStr $Path_Ex1 KLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1"
         ${EndIf}
 
-        ReadRegStr $Path_Ex2               HKLM "SOFTWARE\Wrye Bash" "Extra Path 2"
+        ReadRegStr $Path_Ex2 HKLM "SOFTWARE\Wrye Bash" "Extra Path 2"
         ${If} $Path_Ex2 == $Empty
-            ReadRegStr $Path_Ex2               HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2"
+            ReadRegStr $Path_Ex2 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_OB_Py        HKLM "SOFTWARE\Wrye Bash" "Oblivion Python Version"
+        ReadRegStr $Reg_Value_OB_Py HKLM "SOFTWARE\Wrye Bash" "Oblivion Python Version"
         ${If} $Reg_Value_OB_Py == $Empty
-            ReadRegStr $Reg_Value_OB_Py        HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Python Version"
+            ReadRegStr $Reg_Value_OB_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Python Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_Nehrim_Py    HKLM "SOFTWARE\Wrye Bash" "Nehrim Python Version"
+        ReadRegStr $Reg_Value_Nehrim_Py HKLM "SOFTWARE\Wrye Bash" "Nehrim Python Version"
         ${If} $Reg_Value_Nehrim_Py == $Empty
-            ReadRegStr $Reg_Value_Nehrim_Py    HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Python Version"
+            ReadRegStr $Reg_Value_Nehrim_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Python Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_Skyrim_Py    HKLM "SOFTWARE\Wrye Bash" "Skyrim Python Version"
+        ReadRegStr $Reg_Value_Skyrim_Py HKLM "SOFTWARE\Wrye Bash" "Skyrim Python Version"
         ${If} $Reg_Value_Skyrim_Py == $Empty
-            ReadRegStr $Reg_Value_Skyrim_Py    HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Python Version"
+            ReadRegStr $Reg_Value_Skyrim_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Python Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_Fallout4_Py  HKLM "SOFTWARE\Wrye Bash" "Fallout4 Python Version"
+        ReadRegStr $Reg_Value_Fallout4_Py HKLM "SOFTWARE\Wrye Bash" "Fallout4 Python Version"
         ${If} $Reg_Value_Fallout4_Py == $Empty
-            ReadRegStr $Reg_Value_Fallout4_Py  HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Python Version"
+            ReadRegStr $Reg_Value_Fallout4_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Python Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_SkyrimSE_Py  HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Python Version"
+        ReadRegStr $Reg_Value_SkyrimSE_Py HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Python Version"
         ${If} $Reg_Value_SkyrimSE_Py == $Empty
-            ReadRegStr $Reg_Value_SkyrimSE_Py  HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Python Version"
+            ReadRegStr $Reg_Value_SkyrimSE_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Python Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_Ex1_Py       HKLM "SOFTWARE\Wrye Bash" "Extra Path 1 Python Version"
+        ReadRegStr $Reg_Value_Ex1_Py HKLM "SOFTWARE\Wrye Bash" "Extra Path 1 Python Version"
         ${If} $Reg_Value_Ex1_Py == $Empty
-            ReadRegStr $Reg_Value_Ex1_Py       HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1 Python Version"
+            ReadRegStr $Reg_Value_Ex1_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1 Python Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_Ex2_Py       HKLM "SOFTWARE\Wrye Bash" "Extra Path 2 Python Version"
+        ReadRegStr $Reg_Value_Ex2_Py HKLM "SOFTWARE\Wrye Bash" "Extra Path 2 Python Version"
         ${If} $Reg_Value_Ex2_Py == $Empty
-            ReadRegStr $Reg_Value_Ex2_Py       HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2 Python Version"
+            ReadRegStr $Reg_Value_Ex2_Py HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2 Python Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_OB_Exe       HKLM "SOFTWARE\Wrye Bash" "Oblivion Standalone Version"
+        ReadRegStr $Reg_Value_OB_Exe HKLM "SOFTWARE\Wrye Bash" "Oblivion Standalone Version"
         ${If} $Reg_Value_OB_Exe == $Empty
-            ReadRegStr $Reg_Value_OB_Exe       HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Standalone Version"
+            ReadRegStr $Reg_Value_OB_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Standalone Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_Nehrim_Exe   HKLM "SOFTWARE\Wrye Bash" "Nehrim Standalone Version"
+        ReadRegStr $Reg_Value_Nehrim_Exe HKLM "SOFTWARE\Wrye Bash" "Nehrim Standalone Version"
         ${If} $Reg_Value_Nehrim_Exe == $Empty
-            ReadRegStr $Reg_Value_Nehrim_Exe   HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Standalone Version"
+            ReadRegStr $Reg_Value_Nehrim_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Standalone Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_Skyrim_Exe   HKLM "SOFTWARE\Wrye Bash" "Skyrim Standalone Version"
+        ReadRegStr $Reg_Value_Skyrim_Exe HKLM "SOFTWARE\Wrye Bash" "Skyrim Standalone Version"
         ${If} $Reg_Value_Skyrim_Exe == $Empty
-            ReadRegStr $Reg_Value_Skyrim_Exe   HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Standalone Version"
+            ReadRegStr $Reg_Value_Skyrim_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Standalone Version"
         ${EndIf}
 
         ReadRegStr $Reg_Value_Fallout4_Exe HKLM "SOFTWARE\Wrye Bash" "Fallout4 Standalone Version"
@@ -367,14 +367,14 @@ Unicode true
             ReadRegStr $Reg_Value_SkyrimSE_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Standalone Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_Ex1_Exe      HKLM "SOFTWARE\Wrye Bash" "Extra Path 1 Standalone Version"
+        ReadRegStr $Reg_Value_Ex1_Exe HKLM "SOFTWARE\Wrye Bash" "Extra Path 1 Standalone Version"
         ${If} $Reg_Value_Ex1_Exe == $Empty
-            ReadRegStr $Reg_Value_Ex1_Exe      HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1 Standalone Version"
+            ReadRegStr $Reg_Value_Ex1_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1 Standalone Version"
         ${EndIf}
 
-        ReadRegStr $Reg_Value_Ex2_Exe      HKLM "SOFTWARE\Wrye Bash" "Extra Path 2 Standalone Version"
+        ReadRegStr $Reg_Value_Ex2_Exe HKLM "SOFTWARE\Wrye Bash" "Extra Path 2 Standalone Version"
         ${If} $Reg_Value_Ex2_Exe == $Empty
-            ReadRegStr $Reg_Value_Ex2_Exe      HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2 Standalone Version"
+            ReadRegStr $Reg_Value_Ex2_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2 Standalone Version"
         ${EndIf}
 
         StrCpy $MinVersion_Comtypes '0.6.2'

--- a/scripts/build/installer/main.nsi
+++ b/scripts/build/installer/main.nsi
@@ -299,7 +299,7 @@ Unicode true
 
         ReadRegStr $Path_Ex1 HKLM "SOFTWARE\Wrye Bash" "Extra Path 1"
         ${If} $Path_Ex1 == $Empty
-            ReadRegStr $Path_Ex1 KLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1"
+            ReadRegStr $Path_Ex1 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1"
         ${EndIf}
 
         ReadRegStr $Path_Ex2 HKLM "SOFTWARE\Wrye Bash" "Extra Path 2"

--- a/scripts/build/installer/main.nsi
+++ b/scripts/build/installer/main.nsi
@@ -161,53 +161,221 @@ Unicode true
     Function un.onInit
         StrCpy $Empty ""
         StrCpy $True "True"
-        ReadRegStr $Path_OB                HKLM "Software\Wrye Bash" "Oblivion Path"
-        ReadRegStr $Path_Nehrim            HKLM "Software\Wrye Bash" "Nehrim Path"
-        ReadRegStr $Path_Skyrim            HKLM "Software\Wrye Bash" "Skyrim Path"
-        ReadRegStr $Path_Fallout4          HKLM "Software\Wrye Bash" "Fallout4 Path"
-        ReadRegStr $Path_SkyrimSE          HKLM "Software\Wrye Bash" "SkyrimSE Path"
-        ReadRegStr $Path_Ex1               HKLM "Software\Wrye Bash" "Extra Path 1"
-        ReadRegStr $Path_Ex2               HKLM "Software\Wrye Bash" "Extra Path 2"
-        ReadRegStr $Reg_Value_OB_Py        HKLM "Software\Wrye Bash" "Oblivion Python Version"
-        ReadRegStr $Reg_Value_Nehrim_Py    HKLM "Software\Wrye Bash" "Nehrim Python Version"
-        ReadRegStr $Reg_Value_Skyrim_Py    HKLM "Software\Wrye Bash" "Skyrim Python Version"
-        ReadRegStr $Reg_Value_Fallout4_Py  HKLM "Software\Wrye Bash" "Fallout4 Python Version"
-        ReadRegStr $Reg_Value_SkyrimSE_Py  HKLM "Software\Wrye Bash" "SkyrimSE Python Version"
-        ReadRegStr $Reg_Value_Ex1_Py       HKLM "Software\Wrye Bash" "Extra Path 1 Python Version"
-        ReadRegStr $Reg_Value_Ex2_Py       HKLM "Software\Wrye Bash" "Extra Path 2 Python Version"
-        ReadRegStr $Reg_Value_OB_Exe       HKLM "Software\Wrye Bash" "Oblivion Standalone Version"
-        ReadRegStr $Reg_Value_Nehrim_Exe   HKLM "Software\Wrye Bash" "Nehrim Standalone Version"
-        ReadRegStr $Reg_Value_Skyrim_Exe   HKLM "Software\Wrye Bash" "Skyrim Standalone Version"
-        ReadRegStr $Reg_Value_Fallout4_Exe HKLM "Software\Wrye Bash" "Fallout4 Standalone Version"
-        ReadRegStr $Reg_Value_SkyrimSE_Exe HKLM "Software\Wrye Bash" "SkyrimSE Standalone Version"
-        ReadRegStr $Reg_Value_Ex1_Exe      HKLM "Software\Wrye Bash" "Extra Path 1 Standalone Version"
-        ReadRegStr $Reg_Value_Ex2_Exe      HKLM "Software\Wrye Bash" "Extra Path 2 Standalone Version"
+
+        ReadRegStr $Path_OB                HKLM "SOFTWARE\Wrye Bash" "Oblivion Path"
+        ${If} $Path_OB == $Empty
+            ReadRegStr $Path_OB                HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Nehrim            HKLM "SOFTWARE\Wrye Bash" "Nehrim Path"
+        ${If} $Path_Nehrim == $Empty
+            ReadRegStr $Path_Nehrim            HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Skyrim            HKLM "SOFTWARE\Wrye Bash" "Skyrim Path"
+        ${If} $Path_Skyrim == $Empty
+            ReadRegStr $Path_Skyrim            HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Fallout4          HKLM "SOFTWARE\Wrye Bash" "Fallout4 Path"
+        ${If} $Path_Fallout4 == $Empty
+            ReadRegStr $Path_Fallout4          HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Path"
+        ${EndIf}
+
+        ReadRegStr $Path_SkyrimSE          HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Path"
+        ${If} $Path_SkyrimSE == $Empty
+            ReadRegStr $Path_SkyrimSE          HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Ex1               HKLM "SOFTWARE\Wrye Bash" "Extra Path 1"
+        ${If} $Path_Ex1 == $Empty
+            ReadRegStr $Path_Ex1               HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1"
+        ${EndIf}
+
+        ReadRegStr $Path_Ex2               HKLM "SOFTWARE\Wrye Bash" "Extra Path 2"
+        ${If} $Path_Ex2 == $Empty
+            ReadRegStr $Path_Ex2               HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_OB_Py        HKLM "SOFTWARE\Wrye Bash" "Oblivion Python Version"
+        ${If} $Reg_Value_OB_Py == $Empty
+            ReadRegStr $Reg_Value_OB_Py        HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Nehrim_Py    HKLM "SOFTWARE\Wrye Bash" "Nehrim Python Version"
+        ${If} $Reg_Value_Nehrim_Py == $Empty
+            ReadRegStr $Reg_Value_Nehrim_Py    HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Skyrim_Py    HKLM "SOFTWARE\Wrye Bash" "Skyrim Python Version"
+        ${If} $Reg_Value_Skyrim_Py == $Empty
+            ReadRegStr $Reg_Value_Skyrim_Py    HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Fallout4_Py  HKLM "SOFTWARE\Wrye Bash" "Fallout4 Python Version"
+        ${If} $Reg_Value_Fallout4_Py == $Empty
+            ReadRegStr $Reg_Value_Fallout4_Py  HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_SkyrimSE_Py  HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Python Version"
+        ${If} $Reg_Value_SkyrimSE_Py == $Empty
+            ReadRegStr $Reg_Value_SkyrimSE_Py  HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Ex1_Py       HKLM "SOFTWARE\Wrye Bash" "Extra Path 1 Python Version"
+        ${If} $Reg_Value_Ex1_Py == $Empty
+            ReadRegStr $Reg_Value_Ex1_Py       HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1 Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Ex2_Py       HKLM "SOFTWARE\Wrye Bash" "Extra Path 2 Python Version"
+        ${If} $Reg_Value_Ex2_Py == $Empty
+            ReadRegStr $Reg_Value_Ex2_Py       HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2 Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_OB_Exe       HKLM "SOFTWARE\Wrye Bash" "Oblivion Standalone Version"
+        ${If} $Reg_Value_OB_Exe == $Empty
+            ReadRegStr $Reg_Value_OB_Exe       HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Standalone Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Nehrim_Exe   HKLM "SOFTWARE\Wrye Bash" "Nehrim Standalone Version"
+        ${If} $Reg_Value_Nehrim_Exe == $Empty
+            ReadRegStr $Reg_Value_Nehrim_Exe   HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Standalone Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Skyrim_Exe   HKLM "SOFTWARE\Wrye Bash" "Skyrim Standalone Version"
+        ${If} $Reg_Value_Skyrim_Exe == $Empty
+            ReadRegStr $Reg_Value_Skyrim_Exe   HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Standalone Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Fallout4_Exe HKLM "SOFTWARE\Wrye Bash" "Fallout4 Standalone Version"
+        ${If} $Reg_Value_Fallout4_Exe == $Empty
+            ReadRegStr $Reg_Value_Fallout4_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Standalone Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_SkyrimSE_Exe HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Standalone Version"
+        ${If} $Reg_Value_SkyrimSE_Exe == $Empty
+            ReadRegStr $Reg_Value_SkyrimSE_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Standalone Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Ex1_Exe      HKLM "SOFTWARE\Wrye Bash" "Extra Path 1 Standalone Version"
+        ${If} $Reg_Value_Ex1_Exe == $Empty
+            ReadRegStr $Reg_Value_Ex1_Exe      HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1 Standalone Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Ex2_Exe      HKLM "SOFTWARE\Wrye Bash" "Extra Path 2 Standalone Version"
+        ${If} $Reg_Value_Ex2_Exe == $Empty
+            ReadRegStr $Reg_Value_Ex2_Exe      HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2 Standalone Version"
+        ${EndIf}
     FunctionEnd
 
     Function .onInit
         StrCpy $Empty ""
         StrCpy $True "True"
-        ReadRegStr $Path_OB                HKLM "Software\Wrye Bash" "Oblivion Path"
-        ReadRegStr $Path_Nehrim            HKLM "Software\Wrye Bash" "Nehrim Path"
-        ReadRegStr $Path_Skyrim            HKLM "Software\Wrye Bash" "Skyrim Path"
-        ReadRegStr $Path_Fallout4          HKLM "Software\Wrye Bash" "Fallout4 Path"
-        ReadRegStr $Path_SkyrimSE          HKLM "Software\Wrye Bash" "SkyrimSE Path"
-        ReadRegStr $Path_Ex1               HKLM "Software\Wrye Bash" "Extra Path 1"
-        ReadRegStr $Path_Ex2               HKLM "Software\Wrye Bash" "Extra Path 2"
-        ReadRegStr $Reg_Value_OB_Py        HKLM "Software\Wrye Bash" "Oblivion Python Version"
-        ReadRegStr $Reg_Value_Nehrim_Py    HKLM "Software\Wrye Bash" "Nehrim Python Version"
-        ReadRegStr $Reg_Value_Skyrim_Py    HKLM "Software\Wrye Bash" "Skyrim Python Version"
-        ReadRegStr $Reg_Value_Fallout4_Py  HKLM "Software\Wrye Bash" "Fallout4 Python Version"
-        ReadRegStr $Reg_Value_SkyrimSE_Py  HKLM "Software\Wrye Bash" "SkyrimSE Python Version"
-        ReadRegStr $Reg_Value_Ex1_Py       HKLM "Software\Wrye Bash" "Extra Path 1 Python Version"
-        ReadRegStr $Reg_Value_Ex2_Py       HKLM "Software\Wrye Bash" "Extra Path 2 Python Version"
-        ReadRegStr $Reg_Value_OB_Exe       HKLM "Software\Wrye Bash" "Oblivion Standalone Version"
-        ReadRegStr $Reg_Value_Nehrim_Exe   HKLM "Software\Wrye Bash" "Nehrim Standalone Version"
-        ReadRegStr $Reg_Value_Skyrim_Exe   HKLM "Software\Wrye Bash" "Skyrim Standalone Version"
-        ReadRegStr $Reg_Value_Fallout4_Exe HKLM "Software\Wrye Bash" "Fallout4 Standalone Version"
-        ReadRegStr $Reg_Value_SkyrimSE_Exe HKLM "Software\Wrye Bash" "SkyrimSE Standalone Version"
-        ReadRegStr $Reg_Value_Ex1_Exe      HKLM "Software\Wrye Bash" "Extra Path 1 Standalone Version"
-        ReadRegStr $Reg_Value_Ex2_Exe      HKLM "Software\Wrye Bash" "Extra Path 2 Standalone Version"
+
+        ReadRegStr $Path_OB                HKLM "SOFTWARE\Wrye Bash" "Oblivion Path"
+        ${If} $Path_OB == $Empty
+            ReadRegStr $Path_OB                HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Nehrim            HKLM "SOFTWARE\Wrye Bash" "Nehrim Path"
+        ${If} $Path_Nehrim == $Empty
+            ReadRegStr $Path_Nehrim            HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Skyrim            HKLM "SOFTWARE\Wrye Bash" "Skyrim Path"
+        ${If} $Path_Skyrim == $Empty
+            ReadRegStr $Path_Skyrim            HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Fallout4          HKLM "SOFTWARE\Wrye Bash" "Fallout4 Path"
+        ${If} $Path_Fallout4 == $Empty
+            ReadRegStr $Path_Fallout4          HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Path"
+        ${EndIf}
+
+        ReadRegStr $Path_SkyrimSE          HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Path"
+        ${If} $Path_SkyrimSE == $Empty
+            ReadRegStr $Path_SkyrimSE          HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Ex1               HKLM "SOFTWARE\Wrye Bash" "Extra Path 1"
+        ${If} $Path_Ex1 == $Empty
+            ReadRegStr $Path_Ex1               HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1"
+        ${EndIf}
+
+        ReadRegStr $Path_Ex2               HKLM "SOFTWARE\Wrye Bash" "Extra Path 2"
+        ${If} $Path_Ex2 == $Empty
+            ReadRegStr $Path_Ex2               HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_OB_Py        HKLM "SOFTWARE\Wrye Bash" "Oblivion Python Version"
+        ${If} $Reg_Value_OB_Py == $Empty
+            ReadRegStr $Reg_Value_OB_Py        HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Nehrim_Py    HKLM "SOFTWARE\Wrye Bash" "Nehrim Python Version"
+        ${If} $Reg_Value_Nehrim_Py == $Empty
+            ReadRegStr $Reg_Value_Nehrim_Py    HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Skyrim_Py    HKLM "SOFTWARE\Wrye Bash" "Skyrim Python Version"
+        ${If} $Reg_Value_Skyrim_Py == $Empty
+            ReadRegStr $Reg_Value_Skyrim_Py    HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Fallout4_Py  HKLM "SOFTWARE\Wrye Bash" "Fallout4 Python Version"
+        ${If} $Reg_Value_Fallout4_Py == $Empty
+            ReadRegStr $Reg_Value_Fallout4_Py  HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_SkyrimSE_Py  HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Python Version"
+        ${If} $Reg_Value_SkyrimSE_Py == $Empty
+            ReadRegStr $Reg_Value_SkyrimSE_Py  HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Ex1_Py       HKLM "SOFTWARE\Wrye Bash" "Extra Path 1 Python Version"
+        ${If} $Reg_Value_Ex1_Py == $Empty
+            ReadRegStr $Reg_Value_Ex1_Py       HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1 Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Ex2_Py       HKLM "SOFTWARE\Wrye Bash" "Extra Path 2 Python Version"
+        ${If} $Reg_Value_Ex2_Py == $Empty
+            ReadRegStr $Reg_Value_Ex2_Py       HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2 Python Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_OB_Exe       HKLM "SOFTWARE\Wrye Bash" "Oblivion Standalone Version"
+        ${If} $Reg_Value_OB_Exe == $Empty
+            ReadRegStr $Reg_Value_OB_Exe       HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Standalone Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Nehrim_Exe   HKLM "SOFTWARE\Wrye Bash" "Nehrim Standalone Version"
+        ${If} $Reg_Value_Nehrim_Exe == $Empty
+            ReadRegStr $Reg_Value_Nehrim_Exe   HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Standalone Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Skyrim_Exe   HKLM "SOFTWARE\Wrye Bash" "Skyrim Standalone Version"
+        ${If} $Reg_Value_Skyrim_Exe == $Empty
+            ReadRegStr $Reg_Value_Skyrim_Exe   HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Standalone Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Fallout4_Exe HKLM "SOFTWARE\Wrye Bash" "Fallout4 Standalone Version"
+        ${If} $Reg_Value_Fallout4_Exe == $Empty
+            ReadRegStr $Reg_Value_Fallout4_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Standalone Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_SkyrimSE_Exe HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Standalone Version"
+        ${If} $Reg_Value_SkyrimSE_Exe == $Empty
+            ReadRegStr $Reg_Value_SkyrimSE_Exe HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Standalone Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Ex1_Exe      HKLM "SOFTWARE\Wrye Bash" "Extra Path 1 Standalone Version"
+        ${If} $Reg_Value_Ex1_Exe == $Empty
+            ReadRegStr $Reg_Value_Ex1_Exe      HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1 Standalone Version"
+        ${EndIf}
+
+        ReadRegStr $Reg_Value_Ex2_Exe      HKLM "SOFTWARE\Wrye Bash" "Extra Path 2 Standalone Version"
+        ${If} $Reg_Value_Ex2_Exe == $Empty
+            ReadRegStr $Reg_Value_Ex2_Exe      HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2 Standalone Version"
+        ${EndIf}
 
         StrCpy $MinVersion_Comtypes '0.6.2'
         StrCpy $MinVersion_wx '2.8.12'

--- a/scripts/build/installer/pages.nsi
+++ b/scripts/build/installer/pages.nsi
@@ -518,7 +518,7 @@
             ${EndIf}
             ${If} $Path_Ex2 != $Empty
                 !insertmacro RemoveOldFiles "$Path_Ex2"
-                ${EndIf}
+            ${EndIf}
         ${EndIf}
     FunctionEnd
 

--- a/scripts/build/installer/pages.nsi
+++ b/scripts/build/installer/pages.nsi
@@ -347,13 +347,40 @@
     Function PAGE_FINISH
         !insertmacro MUI_HEADER_TEXT $(PAGE_FINISH_TITLE) $(PAGE_FINISH_SUBTITLE)
 
-        ReadRegStr $Path_OB       HKLM "Software\Wrye Bash" "Oblivion Path"
-        ReadRegStr $Path_Nehrim   HKLM "Software\Wrye Bash" "Nehrim Path"
-        ReadRegStr $Path_Skyrim   HKLM "Software\Wrye Bash" "Skyrim Path"
+        ReadRegStr $Path_OB HKLM "Software\Wrye Bash" "Oblivion Path"
+        ${If} $Path_OB == $Empty
+            ReadRegStr $Path_OB HKLM "Software\WOW6432Node\Wrye Bash" "Oblivion Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Nehrim HKLM "Software\Wrye Bash" "Nehrim Path"
+        ${If} $Path_Nehrim == $Empty
+            ReadRegStr $Path_Nehrim HKLM "Software\WOW6432Node\Wrye Bash" "Nehrim Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Skyrim HKLM "Software\Wrye Bash" "Skyrim Path"
+        ${If} $Path_Skyrim == $Empty
+            ReadRegStr $Path_Skyrim HKLM "Software\WOW6432Node\Wrye Bash" "Skyrim Path"
+        ${EndIf}
+
         ReadRegStr $Path_Fallout4 HKLM "Software\Wrye Bash" "Fallout4 Path"
+        ${If} $Path_Fallout4 == $Empty
+            ReadRegStr $Path_Fallout4 HKLM "Software\WOW6432Node\Wrye Bash" "Fallout4 Path"
+        ${EndIf}
+
         ReadRegStr $Path_SkyrimSE HKLM "Software\Wrye Bash" "SkyrimSE Path"
-        ReadRegStr $Path_Ex1      HKLM "Software\Wrye Bash" "Extra Path 1"
-        ReadRegStr $Path_Ex2      HKLM "Software\Wrye Bash" "Extra Path 2"
+        ${If} $Path_SkyrimSE == $Empty
+            ReadRegStr $Path_SkyrimSE HKLM "Software\WOW6432Node\Wrye Bash" "SkyrimSE Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Ex1 HKLM "Software\Wrye Bash" "Extra Path 1"
+        ${If} $Path_Ex1 == $Empty
+            ReadRegStr $Path_Ex1 HKLM "Software\WOW6432Node\Wrye Bash" "Extra Path 1"
+        ${EndIf}
+
+        ReadRegStr $Path_Ex2 HKLM "Software\Wrye Bash" "Extra Path 2"
+        ${If} $Path_Ex2 == $Empty
+            ReadRegStr $Path_Ex2 HKLM "Software\WOW6432Node\Wrye Bash" "Extra Path 2"
+        ${EndIf}
 
         nsDialogs::Create 1018
             Pop $Dialog

--- a/scripts/build/installer/pages.nsi
+++ b/scripts/build/installer/pages.nsi
@@ -7,6 +7,7 @@
         !insertmacro MUI_HEADER_TEXT $(PAGE_INSTALLLOCATIONS_TITLE) $(PAGE_INSTALLLOCATIONS_SUBTITLE)
         GetFunctionAddress $Function_Browse OnClick_Browse
         GetFunctionAddress $Function_Extra OnClick_Extra
+
         nsDialogs::Create 1018
             Pop $Dialog
 
@@ -17,6 +18,7 @@
         ${NSD_CreateLabel} 0 0 100% 24u "Select which Game(s)/Extra location(s) which you would like to install Wrye Bash for.$\nAlso select which version(s) to install (Standalone exe (default) and/or Python version)."
             Pop $Label
             IntOp $0 0 + 25
+
         ${If} $Path_OB != $Empty
             ${NSD_CreateCheckBox} 0 $0u 30% 13u "Install for Oblivion"
                 Pop $Check_OB
@@ -36,6 +38,7 @@
                 nsDialogs::OnClick $Browse_OB $Function_Browse
             IntOp $0 $0 + 13
         ${EndIf}
+
         ${If} $Path_Nehrim != $Empty
             ${NSD_CreateCheckBox} 0 $0u 30% 13u "Install for Nehrim"
                 Pop $Check_Nehrim
@@ -55,6 +58,7 @@
                 nsDialogs::OnClick $Browse_Nehrim $Function_Browse
             IntOp $0 $0 + 13
         ${EndIf}
+
         ${If} $Path_Skyrim != $Empty
             ${NSD_CreateCheckBox} 0 $0u 30% 13u "Install for Skyrim"
                 Pop $Check_Skyrim
@@ -74,6 +78,7 @@
                 nsDialogs::OnClick $Browse_Skyrim $Function_Browse
             IntOp $0 $0 + 13
         ${EndIf}
+
         ${If} $Path_Fallout4 != $Empty
             ${NSD_CreateCheckBox} 0 $0u 30% 13u "Install for Fallout4"
                 Pop $Check_Fallout4
@@ -93,6 +98,7 @@
                 nsDialogs::OnClick $Browse_Fallout4 $Function_Browse
             IntOp $0 $0 + 13
         ${EndIf}
+
         ${If} $Path_SkyrimSE != $Empty
             ${NSD_CreateCheckBox} 0 $0u 30% 13u "Install for SkyrimSE"
                 Pop $Check_SkyrimSE
@@ -112,6 +118,7 @@
                 nsDialogs::OnClick $Browse_SkyrimSE $Function_Browse
             IntOp $0 $0 + 13
         ${EndIf}
+
         ${NSD_CreateCheckBox} 0 $0u 100% 13u "Install to extra locations"
             Pop $Check_Extra
             ${NSD_SetState} $Check_Extra $CheckState_Extra
@@ -150,6 +157,7 @@
                 ${NSD_CreateBrowseButton} -10% $0u 5% 13u "..."
                     Pop $Browse_Ex2
                     nsDialogs::OnClick $Browse_Ex2 $Function_Browse
+
         ${If} $CheckState_Extra != ${BST_CHECKED}
             ShowWindow $Check_Ex1 ${SW_HIDE}
             ShowWindow $Check_Ex1_Py ${SW_HIDE}
@@ -162,6 +170,7 @@
             ShowWindow $PathDialogue_Ex2 ${SW_HIDE}
             ShowWindow $Browse_Ex2 ${SW_HIDE}
         ${EndIf}
+
         nsDialogs::Show
     FunctionEnd
 
@@ -197,36 +206,43 @@
         ${NSD_GetState} $Check_SkyrimSE_Py $CheckState_SkyrimSE_Py
         ${NSD_GetState} $Check_Ex1_Py $CheckState_Ex1_Py
         ${NSD_GetState} $Check_Ex2_Py $CheckState_Ex2_Py
+
         ${If} $CheckState_OB_Py == ${BST_CHECKED}
         ${AndIf} $CheckState_OB == ${BST_CHECKED}
             StrCpy $PythonVersionInstall $True
-        ${Endif}
+        ${EndIf}
+
         ${If} $CheckState_Nehrim_Py == ${BST_CHECKED}
         ${AndIf} $CheckState_Nehrim == ${BST_CHECKED}
             StrCpy $PythonVersionInstall $True
-        ${Endif}
+        ${EndIf}
+
         ${If} $CheckState_Skyrim_Py == ${BST_CHECKED}
         ${AndIf} $CheckState_Skyrim == ${BST_CHECKED}
             StrCpy $PythonVersionInstall $True
         ${EndIf}
+
         ${If} $CheckState_Fallout4_Py == ${BST_CHECKED}
         ${AndIf} $CheckState_Fallout4 == ${BST_CHECKED}
             StrCpy $PythonVersionInstall $True
         ${EndIf}
+
         ${If} $CheckState_SkyrimSE_Py == ${BST_CHECKED}
         ${AndIf} $CheckState_SkyrimSE == ${BST_CHECKED}
             StrCpy $PythonVersionInstall $True
         ${EndIf}
+
         ${If} $CheckState_Ex1_Py == ${BST_CHECKED}
         ${AndIf} $CheckState_Extra == ${BST_CHECKED}
         ${AndIf} $CheckState_Ex1 == ${BST_CHECKED}
             StrCpy $PythonVersionInstall $True
-        ${Endif}
+        ${EndIf}
+
         ${If} $CheckState_Ex2_Py == ${BST_CHECKED}
         ${AndIf} $CheckState_Extra == ${BST_CHECKED}
         ${AndIf} $CheckState_Ex2 == ${BST_CHECKED}
             StrCpy $PythonVersionInstall $True
-        ${Endif}
+        ${EndIf}
 
         ; Standalone states
         ${NSD_GetState} $Check_OB_Exe $CheckState_OB_Exe
@@ -239,33 +255,39 @@
         ${If} $CheckState_OB_Exe == ${BST_CHECKED}
         ${AndIf} $CheckState_OB == ${BST_CHECKED}
             StrCpy $ExeVersionInstall $True
-        ${Endif}
+        ${EndIf}
+
         ${If} $CheckState_Nehrim_Exe == ${BST_CHECKED}
         ${AndIf} $CheckState_Nehrim == ${BST_CHECKED}
             StrCpy $ExeVersionInstall $True
-        ${Endif}
+        ${EndIf}
+
         ${If} $CheckState_Skyrim_Exe == ${BST_CHECKED}
         ${AndIf} $CheckState_Skyrim == ${BST_CHECKED}
             StrCpy $ExeVersionInstall $True
         ${EndIf}
+
         ${If} $CheckState_Fallout4_Exe == ${BST_CHECKED}
         ${AndIf} $CheckState_Fallout4 == ${BST_CHECKED}
             StrCpy $ExeVersionInstall $True
         ${EndIf}
+
         ${If} $CheckState_SkyrimSE_Exe == ${BST_CHECKED}
         ${AndIf} $CheckState_SkyrimSE == ${BST_CHECKED}
             StrCpy $ExeVersionInstall $True
         ${EndIf}
+
         ${If} $CheckState_Ex1_Exe == ${BST_CHECKED}
         ${AndIf} $CheckState_Extra == ${BST_CHECKED}
         ${AndIf} $CheckState_Ex1 == ${BST_CHECKED}
             StrCpy $ExeVersionInstall $True
-        ${Endif}
+        ${EndIf}
+
         ${If} $CheckState_Ex2_Exe == ${BST_CHECKED}
         ${AndIf} $CheckState_Extra == ${BST_CHECKED}
         ${AndIf} $CheckState_Ex2 == ${BST_CHECKED}
             StrCpy $ExeVersionInstall $True
-        ${Endif}
+        ${EndIf}
     FunctionEnd
 
 
@@ -279,49 +301,54 @@
             ${StrLoc} $0 $Path_OB "$PROGRAMFILES\" ">"
             ${If} "0" == $0
                 StrCpy $1 $True
-            ${Endif}
-        ${Endif}
+            ${EndIf}
+        ${EndIf}
         ${If} $CheckState_Nehrim == ${BST_CHECKED}
             ${StrLoc} $0 $Path_Nehrim "$PROGRAMFILES\" ">"
             ${If} "0" == $0
                 StrCpy $1 $True
-            ${Endif}
-        ${Endif}
+            ${EndIf}
+        ${EndIf}
+
         ${If} $CheckState_Skyrim == ${BST_CHECKED}
             ${StrLoc} $0 $Path_Skyrim "$PROGRAMFILES\" ">"
             ${If} "0" == $0
                 StrCpy $1 $True
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Fallout4 == ${BST_CHECKED}
             ${StrLoc} $0 $Path_Fallout4 "$PROGRAMFILES\" ">"
             ${If} "0" == $0
                 StrCpy $1 $True
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_SkyrimSE == ${BST_CHECKED}
             ${StrLoc} $0 $Path_SkyrimSE "$PROGRAMFILES\" ">"
             ${If} "0" == $0
                 StrCpy $1 $True
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Ex1 == ${BST_CHECKED}
             ${StrLoc} $0 $Path_Ex1 "$PROGRAMFILES\" ">"
             ${If} "0" == $0
                 StrCpy $1 $True
-            ${Endif}
-        ${Endif}
+            ${EndIf}
+        ${EndIf}
+
         ${If} $CheckState_Ex2 == ${BST_CHECKED}
             ${StrLoc} $0 $Path_Ex2 "$PROGRAMFILES\" ">"
             ${If} "0" == $0
                 StrCpy $1 $True
-            ${Endif}
-        ${Endif}
+            ${EndIf}
+        ${EndIf}
 
         ${If} $1 == $Empty
             ; nothing installed in program files: skip this page
             Abort
-        ${Endif}
+        ${EndIf}
 
         nsDialogs::Create 1018
             Pop $Dialog
@@ -384,6 +411,7 @@
 
         nsDialogs::Create 1018
             Pop $Dialog
+
         ${If} $Dialog == error
             Abort
         ${EndIf}
@@ -392,51 +420,62 @@
         ${NSD_CreateLabel} 0 0 100% 16u "Please select which Wrye Bash installation(s), if any, you would like to run right now:"
             Pop $Label
         IntOp $0 0 + 17
+
         ${If} $Path_OB != $Empty
             ${NSD_CreateCheckBox} 0 $0u 100% 8u "Oblivion"
                 Pop $Check_OB
             IntOp $0 $0 + 9
         ${EndIf}
+
         ${If} $Path_Nehrim != $Empty
             ${NSD_CreateCheckBox} 0 $0u 100% 8u "Nehrim"
                 Pop $Check_Nehrim
             IntOp $0 $0 + 9
         ${EndIf}
+
         ${If} $Path_Skyrim != $Empty
             ${NSD_CreateCheckBox} 0 $0u 100% 8u "Skyrim"
                 Pop $Check_Skyrim
             IntOp $0 $0 + 9
         ${EndIf}
+
         ${If} $Path_Fallout4 != $Empty
             ${NSD_CreateCheckBox} 0 $0u 100% 8u "Fallout4"
                 Pop $Check_Fallout4
             IntOp $0 $0 + 9
         ${EndIf}
+
         ${If} $Path_SkyrimSE != $Empty
             ${NSD_CreateCheckBox} 0 $0u 100% 8u "SkyrimSE"
                 Pop $Check_SkyrimSE
             IntOp $0 $0 + 9
         ${EndIf}
+
         ${If} $Path_Ex1 != $Empty
             ${NSD_CreateCheckBox} 0 $0u 100% 8u $Path_Ex1
                 Pop $Check_Ex1
             IntOp $0 $0 + 9
         ${EndIf}
+
         ${If} $Path_Ex2 != $Empty
             ${NSD_CreateCheckBox} 0 $0u 100% 8u $Path_Ex2
                 Pop $Check_Ex2
             IntOp $0 $0 + 9
         ${EndIf}
+
         IntOp $0 $0 + 9
         IntOp $1 0 + 0
+
         ${NSD_CreateCheckBox} $1% $0u 25% 8u "View Readme"
             Pop $Check_Readme
             ${NSD_SetState} $Check_Readme ${BST_CHECKED}
             IntOp $1 $1 + 25
+
         ${NSD_CreateCheckBox} $1% $0u 75% 8u "Delete files from old Bash versions"
             Pop $Check_DeleteOldFiles
             EnableWindow $Check_DeleteOldFiles 0 ; always delete old files
             ${NSD_SetState} $Check_DeleteOldFiles ${BST_CHECKED}
+
         nsDialogs::Show
     FunctionEnd
 
@@ -457,6 +496,7 @@
                 ExecShell "open" "$Path_OB\Mopy\Wrye Bash.exe"
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Nehrim == ${BST_CHECKED}
             SetOutPath "$Path_Nehrim\Mopy"
             ${If} $CheckState_Nehrim_Py == ${BST_CHECKED}
@@ -465,6 +505,7 @@
                 ExecShell "open" "$Path_Nehrim\Mopy\Wrye Bash.exe"
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Skyrim == ${BST_CHECKED}
             SetOutPath "$Path_Skyrim\Mopy"
             ${If} $CheckState_Skyrim_Py == ${BST_CHECKED}
@@ -473,6 +514,7 @@
                 ExecShell "open" "$Path_Skyrim\Mopy\Wrye Bash.exe"
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Fallout4 == ${BST_CHECKED}
             SetOutPath "$Path_Fallout4\Mopy"
             ${If} $CheckState_Fallout4_Py == ${BST_CHECKED}
@@ -481,6 +523,7 @@
                 ExecShell "open" "$Path_Fallout4\Mopy\Wrye Bash.exe"
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_SkyrimSE == ${BST_CHECKED}
             SetOutPath "$Path_SkyrimSE\Mopy"
             ${If} $CheckState_SkyrimSE_Py == ${BST_CHECKED}
@@ -489,6 +532,7 @@
                 ExecShell "open" "$Path_SkyrimSE\Mopy\Wrye Bash.exe"
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Ex1 == ${BST_CHECKED}
             SetOutPath "$Path_Ex1\Mopy"
             ${If} $CheckState_Ex1_Py == ${BST_CHECKED}
@@ -497,6 +541,7 @@
                 ExecShell "open" "$Path_Ex1\Mopy\Wrye Bash.exe"
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Ex2 == ${BST_CHECKED}
             SetOutPath "$Path_Ex2\Mopy"
             ${If} $CheckState_Ex2_Py == ${BST_CHECKED}
@@ -505,7 +550,9 @@
                 ExecShell "open" "$Path_Ex2\Mopy\Wrye Bash.exe"
             ${EndIf}
         ${EndIf}
+
         ${NSD_GetState} $Check_Readme $0
+
         ${If} $0 == ${BST_CHECKED}
             ${If} $Path_OB != $Empty
                 ExecShell "open" "$Path_OB\Mopy\Docs\Wrye Bash General Readme.html"
@@ -523,7 +570,9 @@
                 ExecShell "open" "$Path_Ex2\Mopy\Docs\Wrye Bash General Readme.html"
             ${EndIf}
         ${EndIf}
+
         ${NSD_GetState} $Check_DeleteOldFiles $0
+
         ${If} $0 == ${BST_CHECKED}
             ${If} $Path_OB != $Empty
                 !insertmacro RemoveOldFiles "$Path_OB"
@@ -577,6 +626,7 @@
                 nsDialogs::OnClick $Browse_OB $Function_Browse
             IntOp $0 $0 + 13
         ${EndIf}
+
         ${If} $Path_Nehrim != $Empty
             ${NSD_CreateCheckBox} 0 $0u 100% 13u "Nehrim"
                 Pop $Check_Nehrim
@@ -589,6 +639,7 @@
                 nsDialogs::OnClick $Browse_Nehrim $Function_Browse
             IntOp $0 $0 + 13
         ${EndIf}
+
         ${If} $Path_Skyrim != $Empty
             ${NSD_CreateCheckBox} 0 $0u 100% 13u "&Skyrim"
                 Pop $Check_Skyrim
@@ -601,6 +652,7 @@
                 nsDialogs::OnClick $Browse_Skyrim $Function_Browse
             IntOp $0 $0 + 13
         ${EndIf}
+
         ${If} $Path_Fallout4 != $Empty
             ${NSD_CreateCheckBox} 0 $0u 100% 13u "&Fallout4"
                 Pop $Check_Fallout4
@@ -613,6 +665,7 @@
                 nsDialogs::OnClick $Browse_Fallout4 $Function_Browse
             IntOp $0 $0 + 13
         ${EndIf}
+
         ${If} $Path_SkyrimSE != $Empty
             ${NSD_CreateCheckBox} 0 $0u 100% 13u "&SkyrimSE"
                 Pop $Check_SkyrimSE
@@ -625,6 +678,7 @@
                 nsDialogs::OnClick $Browse_SkyrimSE $Function_Browse
             IntOp $0 $0 + 13
         ${EndIf}
+
         ${If} $Path_Ex1 != $Empty
             ${NSD_CreateCheckBox} 0 $0u 100% 13u "Extra Location 1"
                 Pop $Check_Ex1
@@ -637,6 +691,7 @@
                 nsDialogs::OnClick $Browse_Ex1 $Function_Browse
             IntOp $0 $0 + 13
         ${EndIf}
+
         ${If} $Path_Ex2 != $Empty
             ${NSD_CreateCheckBox} 0 $0u 100% 13u "Extra Location 2"
                 Pop $Check_Ex2

--- a/scripts/build/installer/pages.nsi
+++ b/scripts/build/installer/pages.nsi
@@ -1,6 +1,7 @@
 ; pages.nsi
 ; Custom pages for the Wrye Bash NSIS installer / uninstaller
 
+!include "macros.nsh"
 
 ;---------------------------- Install Locations Page
     Function PAGE_INSTALLLOCATIONS
@@ -374,40 +375,7 @@
     Function PAGE_FINISH
         !insertmacro MUI_HEADER_TEXT $(PAGE_FINISH_TITLE) $(PAGE_FINISH_SUBTITLE)
 
-        ReadRegStr $Path_OB HKLM "Software\Wrye Bash" "Oblivion Path"
-        ${If} $Path_OB == $Empty
-            ReadRegStr $Path_OB HKLM "Software\WOW6432Node\Wrye Bash" "Oblivion Path"
-        ${EndIf}
-
-        ReadRegStr $Path_Nehrim HKLM "Software\Wrye Bash" "Nehrim Path"
-        ${If} $Path_Nehrim == $Empty
-            ReadRegStr $Path_Nehrim HKLM "Software\WOW6432Node\Wrye Bash" "Nehrim Path"
-        ${EndIf}
-
-        ReadRegStr $Path_Skyrim HKLM "Software\Wrye Bash" "Skyrim Path"
-        ${If} $Path_Skyrim == $Empty
-            ReadRegStr $Path_Skyrim HKLM "Software\WOW6432Node\Wrye Bash" "Skyrim Path"
-        ${EndIf}
-
-        ReadRegStr $Path_Fallout4 HKLM "Software\Wrye Bash" "Fallout4 Path"
-        ${If} $Path_Fallout4 == $Empty
-            ReadRegStr $Path_Fallout4 HKLM "Software\WOW6432Node\Wrye Bash" "Fallout4 Path"
-        ${EndIf}
-
-        ReadRegStr $Path_SkyrimSE HKLM "Software\Wrye Bash" "SkyrimSE Path"
-        ${If} $Path_SkyrimSE == $Empty
-            ReadRegStr $Path_SkyrimSE HKLM "Software\WOW6432Node\Wrye Bash" "SkyrimSE Path"
-        ${EndIf}
-
-        ReadRegStr $Path_Ex1 HKLM "Software\Wrye Bash" "Extra Path 1"
-        ${If} $Path_Ex1 == $Empty
-            ReadRegStr $Path_Ex1 HKLM "Software\WOW6432Node\Wrye Bash" "Extra Path 1"
-        ${EndIf}
-
-        ReadRegStr $Path_Ex2 HKLM "Software\Wrye Bash" "Extra Path 2"
-        ${If} $Path_Ex2 == $Empty
-            ReadRegStr $Path_Ex2 HKLM "Software\WOW6432Node\Wrye Bash" "Extra Path 2"
-        ${EndIf}
+        !insertmacro UpdateRegistryPaths
 
         nsDialogs::Create 1018
             Pop $Dialog

--- a/scripts/build/installer/pages.nsi
+++ b/scripts/build/installer/pages.nsi
@@ -441,7 +441,7 @@
         ${If} $CheckState_Skyrim == ${BST_CHECKED}
             SetOutPath "$Path_Skyrim\Mopy"
             ${If} $CheckState_Skyrim_Py == ${BST_CHECKED}
-                ExecShell "open" '"%Path_Skyrim\Mopy\Wrye Bash Launcher.pyw"'
+                ExecShell "open" '"$Path_Skyrim\Mopy\Wrye Bash Launcher.pyw"'
             ${ElseIf} $CheckState_Skyrim_Exe == ${BST_CHECKED}
                 ExecShell "open" "$Path_Skyrim\Mopy\Wrye Bash.exe"
             ${EndIf}
@@ -449,7 +449,7 @@
         ${If} $CheckState_Fallout4 == ${BST_CHECKED}
             SetOutPath "$Path_Fallout4\Mopy"
             ${If} $CheckState_Fallout4_Py == ${BST_CHECKED}
-                ExecShell "open" '"%Path_Fallout4\Mopy\Wrye Bash Launcher.pyw"'
+                ExecShell "open" '"$Path_Fallout4\Mopy\Wrye Bash Launcher.pyw"'
             ${ElseIf} $CheckState_Fallout4_Exe == ${BST_CHECKED}
                 ExecShell "open" "$Path_Fallout4\Mopy\Wrye Bash.exe"
             ${EndIf}
@@ -457,7 +457,7 @@
         ${If} $CheckState_SkyrimSE == ${BST_CHECKED}
             SetOutPath "$Path_SkyrimSE\Mopy"
             ${If} $CheckState_SkyrimSE_Py == ${BST_CHECKED}
-                ExecShell "open" '"%Path_SkyrimSE\Mopy\Wrye Bash Launcher.pyw"'
+                ExecShell "open" '"$Path_SkyrimSE\Mopy\Wrye Bash Launcher.pyw"'
             ${ElseIf} $CheckState_SkyrimSE_Exe == ${BST_CHECKED}
                 ExecShell "open" "$Path_SkyrimSE\Mopy\Wrye Bash.exe"
             ${EndIf}

--- a/scripts/build/installer/uninstall.nsi
+++ b/scripts/build/installer/uninstall.nsi
@@ -5,7 +5,12 @@
 
 ;-------------------------------- The Uninstallation Code:
     Section "Uninstall"
+
+        ; Ensure that we're working with current registry paths
+        !insertmacro UpdateRegistryPaths
+
         ; Remove files and Directories - Directories are only deleted if empty.
+
         ${If} $CheckState_OB == ${BST_CHECKED}
             ${If} $Path_OB != $Empty
                 !insertmacro UninstallBash $Path_OB "Oblivion"
@@ -48,71 +53,39 @@
             ${EndIf}
         ${EndIf}
 
+        ; Refresh the registry paths
+        !insertmacro UpdateRegistryPaths
 
-        ;If it is a complete uninstall, remove the shared data:
-        ;Added support for 64-bit operating systems --fireundubh
-
-        ReadRegStr $Path_OB       HKLM "SOFTWARE\Wrye Bash" "Oblivion Path"
-        ${If} $Path_OB == $Empty
-            ReadRegStr $Path_OB HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Path"
-        ${EndIf}
-
-        ReadRegStr $Path_Nehrim   HKLM "Software\Wrye Bash" "Nehrim Path"
-        ${If} $Path_Nehrim == $Empty
-            ReadRegStr $Path_Nehrim HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Path"
-        ${EndIf}
-
-        ReadRegStr $Path_Skyrim   HKLM "Software\Wrye Bash" "Skyrim Path"
-        ${If} $Path_Skyrim == $Empty
-            ReadRegStr $Path_Skyrim HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Path"
-        ${EndIf}
-
-        ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\Wrye Bash" "Fallout4 Path"
-        ${If} $Path_Fallout4 == $Empty
-            ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Path"
-        ${EndIf}
-
-        ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Path"
-        ${If} $Path_SkyrimSE == $Empty
-            ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Path"
-        ${EndIf}
-
-        ReadRegStr $Path_Ex1      HKLM "SOFTWARE\Wrye Bash" "Extra Path 1"
-        ${If} $Path_Ex1 == $Empty
-            ReadRegStr $Path_Ex1 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1"
-        ${EndIf}
-
-        ReadRegStr $Path_Ex2      HKLM "SOFTWARE\Wrye Bash" "Extra Path 2"
-        ${If} $Path_Ex2 == $Empty
-            ReadRegStr $Path_Ex2 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2"
-        ${EndIf}
+        ; If it is a complete uninstall, remove the shared data:
+        ; all registry paths must be clear for the application to completely uninstall
+        ; WARNING: if the uninstaller is not cleaned up, then uninstallation failed
 
         ${If} $Path_OB == $Empty
-            ${AndIf} $Path_Nehrim == $Empty
-            ${AndIf} $Path_Skyrim == $Empty
-            ${AndIf} $Path_Fallout4 == $Empty
-            ${AndIf} $Path_SkyrimSE == $Empty
-            ${AndIf} $Path_Ex1 == $Empty
-            ${AndIf} $Path_Ex2 == $Empty
-                DeleteRegKey HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash"
-                ReadRegStr $0 HKLM "SOFTWARE\Wrye Bash" "Installer Path"
-                ${If} $0 == $Empty
-                    ReadRegStr $0 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Installer Path"
-                    DeleteRegKey HKLM "SOFTWARE\WOW6432Node\Wrye Bash"
-                ${Else}
-                    DeleteRegKey HKLM "SOFTWARE\Wrye Bash"
-                ${EndIf}
-                ;Delete stupid Windows created registry keys:
-                DeleteRegKey HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\App Management\ARPCache\Wrye Bash"
-                DeleteRegValue HKCR "Local Settings\Software\Microsoft\Windows\Shell\MuiCache" "$COMMONFILES\Wrye Bash\Uninstall.exe"
-                DeleteRegValue HKCU "SOFTWARE\Classes\Local Settings\Software\Microsoft\Windows\Shell\MuiCache" "$COMMONFILES\Wrye Bash\Uninstall.exe"
-                DeleteRegValue HKCU "SOFTWARE\Microsoft\Windows\ShellNoRoam\MuiCache" "$COMMONFILES\Wrye Bash\Uninstall.exe"
-                DeleteRegValue HKCR "Local Settings\Software\Microsoft\Windows\Shell\MuiCache" "$0"
-                DeleteRegValue HKCU "SOFTWARE\Classes\Local Settings\Software\Microsoft\Windows\Shell\MuiCache" "$0"
-                DeleteRegValue HKCU "SOFTWARE\Microsoft\Windows\ShellNoRoam\MuiCache" "$0"
-                Delete "$SMPROGRAMS\Wrye Bash\*.*"
-                RMDir "$SMPROGRAMS\Wrye Bash"
-                Delete "$COMMONFILES\Wrye Bash\*.*"
-                RMDir "$COMMONFILES\Wrye Bash"
+        ${AndIf} $Path_Nehrim == $Empty
+        ${AndIf} $Path_Skyrim == $Empty
+        ${AndIf} $Path_Fallout4 == $Empty
+        ${AndIf} $Path_SkyrimSE == $Empty
+        ${AndIf} $Path_Ex1 == $Empty
+        ${AndIf} $Path_Ex2 == $Empty
+            DeleteRegKey HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash"
+            ReadRegStr $0 HKLM "SOFTWARE\Wrye Bash" "Installer Path"
+            ${If} $0 == $Empty
+                ReadRegStr $0 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Installer Path"
+                DeleteRegKey HKLM "SOFTWARE\WOW6432Node\Wrye Bash"
+            ${Else}
+                DeleteRegKey HKLM "SOFTWARE\Wrye Bash"
             ${EndIf}
-        SectionEnd
+            ;Delete stupid Windows created registry keys:
+            DeleteRegKey HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\App Management\ARPCache\Wrye Bash"
+            DeleteRegValue HKCR "Local Settings\Software\Microsoft\Windows\Shell\MuiCache" "$COMMONFILES\Wrye Bash\Uninstall.exe"
+            DeleteRegValue HKCU "SOFTWARE\Classes\Local Settings\Software\Microsoft\Windows\Shell\MuiCache" "$COMMONFILES\Wrye Bash\Uninstall.exe"
+            DeleteRegValue HKCU "SOFTWARE\Microsoft\Windows\ShellNoRoam\MuiCache" "$COMMONFILES\Wrye Bash\Uninstall.exe"
+            DeleteRegValue HKCR "Local Settings\Software\Microsoft\Windows\Shell\MuiCache" "$0"
+            DeleteRegValue HKCU "SOFTWARE\Classes\Local Settings\Software\Microsoft\Windows\Shell\MuiCache" "$0"
+            DeleteRegValue HKCU "SOFTWARE\Microsoft\Windows\ShellNoRoam\MuiCache" "$0"
+            Delete "$SMPROGRAMS\Wrye Bash\*.*"
+            RMDir "$SMPROGRAMS\Wrye Bash"
+            Delete "$COMMONFILES\Wrye Bash\*.*"
+            RMDir "$COMMONFILES\Wrye Bash"
+        ${EndIf}
+    SectionEnd

--- a/scripts/build/installer/uninstall.nsi
+++ b/scripts/build/installer/uninstall.nsi
@@ -11,31 +11,37 @@
                 !insertmacro UninstallBash $Path_OB "Oblivion"
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Nehrim == ${BST_CHECKED}
             ${If} $Path_Nehrim != $Empty
                 !insertmacro UninstallBash $Path_Nehrim "Nehrim"
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Skyrim == ${BST_CHECKED}
             ${If} $Path_Skyrim != $Empty
                 !insertmacro UninstallBash $Path_Skyrim "Skyrim"
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Fallout4 == ${BST_CHECKED}
             ${If} $Path_Fallout4 != $Empty
                 !insertmacro UninstallBash $Path_Fallout4 "Fallout4"
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_SkyrimSE == ${BST_CHECKED}
             ${If} $Path_SkyrimSE != $Empty
                 !insertmacro UninstallBash $Path_SkyrimSE "SkyrimSE"
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Ex1 == ${BST_CHECKED}
             ${If} $Path_Ex1 != $Empty
                 !insertmacro UninstallBash $Path_Ex1 "Extra Path 1"
             ${EndIf}
         ${EndIf}
+
         ${If} $CheckState_Ex2 == ${BST_CHECKED}
             ${If} $Path_Ex2 != $Empty
                 !insertmacro UninstallBash $Path_Ex2 "Extra Path 2"

--- a/scripts/build/installer/uninstall.nsi
+++ b/scripts/build/installer/uninstall.nsi
@@ -43,14 +43,44 @@
         ${EndIf}
 
 
-        ;If it is a complete uninstall remove the shared data:
-        ReadRegStr $Path_OB       HKLM "Software\Wrye Bash" "Oblivion Path"
+        ;If it is a complete uninstall, remove the shared data:
+        ;Added support for 64-bit operating systems --fireundubh
+
+        ReadRegStr $Path_OB       HKLM "SOFTWARE\Wrye Bash" "Oblivion Path"
+        ${If} $Path_OB == $Empty
+            ReadRegStr $Path_OB HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Oblivion Path"
+        ${EndIf}
+
         ReadRegStr $Path_Nehrim   HKLM "Software\Wrye Bash" "Nehrim Path"
+        ${If} $Path_Nehrim == $Empty
+            ReadRegStr $Path_Nehrim HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Nehrim Path"
+        ${EndIf}
+
         ReadRegStr $Path_Skyrim   HKLM "Software\Wrye Bash" "Skyrim Path"
-        ReadRegStr $Path_Fallout4 HKLM "Software\Wrye Bash" "Fallout4 Path"
-        ReadRegStr $Path_SkyrimSE HKLM "Software\Wrye Bash" "SkyrimSE Path"
-        ReadRegStr $Path_Ex1      HKLM "Software\Wrye Bash" "Extra Path 1"
-        ReadRegStr $Path_Ex2      HKLM "Software\Wrye Bash" "Extra Path 2"
+        ${If} $Path_Skyrim == $Empty
+            ReadRegStr $Path_Skyrim HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Skyrim Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\Wrye Bash" "Fallout4 Path"
+        ${If} $Path_Fallout4 == $Empty
+            ReadRegStr $Path_Fallout4 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Fallout4 Path"
+        ${EndIf}
+
+        ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\Wrye Bash" "SkyrimSE Path"
+        ${If} $Path_SkyrimSE == $Empty
+            ReadRegStr $Path_SkyrimSE HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "SkyrimSE Path"
+        ${EndIf}
+
+        ReadRegStr $Path_Ex1      HKLM "SOFTWARE\Wrye Bash" "Extra Path 1"
+        ${If} $Path_Ex1 == $Empty
+            ReadRegStr $Path_Ex1 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 1"
+        ${EndIf}
+
+        ReadRegStr $Path_Ex2      HKLM "SOFTWARE\Wrye Bash" "Extra Path 2"
+        ${If} $Path_Ex2 == $Empty
+            ReadRegStr $Path_Ex2 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Extra Path 2"
+        ${EndIf}
+
         ${If} $Path_OB == $Empty
             ${AndIf} $Path_Nehrim == $Empty
             ${AndIf} $Path_Skyrim == $Empty
@@ -58,17 +88,22 @@
             ${AndIf} $Path_SkyrimSE == $Empty
             ${AndIf} $Path_Ex1 == $Empty
             ${AndIf} $Path_Ex2 == $Empty
-                DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash"
-                ReadRegStr $0 HKLM "Software\Wrye Bash" "Installer Path"
-                DeleteRegKey HKLM "SOFTWARE\Wrye Bash"
+                DeleteRegKey HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Wrye Bash"
+                ReadRegStr $0 HKLM "SOFTWARE\Wrye Bash" "Installer Path"
+                ${If} $0 == $Empty
+                    ReadRegStr $0 HKLM "SOFTWARE\WOW6432Node\Wrye Bash" "Installer Path"
+                    DeleteRegKey HKLM "SOFTWARE\WOW6432Node\Wrye Bash"
+                ${Else}
+                    DeleteRegKey HKLM "SOFTWARE\Wrye Bash"
+                ${EndIf}
                 ;Delete stupid Windows created registry keys:
-                DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\App Management\ARPCache\Wrye Bash"
+                DeleteRegKey HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\App Management\ARPCache\Wrye Bash"
                 DeleteRegValue HKCR "Local Settings\Software\Microsoft\Windows\Shell\MuiCache" "$COMMONFILES\Wrye Bash\Uninstall.exe"
-                DeleteRegValue HKCU "Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\MuiCache" "$COMMONFILES\Wrye Bash\Uninstall.exe"
-                DeleteRegValue HKCU "Software\Microsoft\Windows\ShellNoRoam\MuiCache" "$COMMONFILES\Wrye Bash\Uninstall.exe"
+                DeleteRegValue HKCU "SOFTWARE\Classes\Local Settings\Software\Microsoft\Windows\Shell\MuiCache" "$COMMONFILES\Wrye Bash\Uninstall.exe"
+                DeleteRegValue HKCU "SOFTWARE\Microsoft\Windows\ShellNoRoam\MuiCache" "$COMMONFILES\Wrye Bash\Uninstall.exe"
                 DeleteRegValue HKCR "Local Settings\Software\Microsoft\Windows\Shell\MuiCache" "$0"
-                DeleteRegValue HKCU "Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\MuiCache" "$0"
-                DeleteRegValue HKCU "Software\Microsoft\Windows\ShellNoRoam\MuiCache" "$0"
+                DeleteRegValue HKCU "SOFTWARE\Classes\Local Settings\Software\Microsoft\Windows\Shell\MuiCache" "$0"
+                DeleteRegValue HKCU "SOFTWARE\Microsoft\Windows\ShellNoRoam\MuiCache" "$0"
                 Delete "$SMPROGRAMS\Wrye Bash\*.*"
                 RMDir "$SMPROGRAMS\Wrye Bash"
                 Delete "$COMMONFILES\Wrye Bash\*.*"


### PR DESCRIPTION
- Fixed an issue where the uninstaller could not resolve a bad registry state when the Extra Path options were used during a previous install
- Fixed an issue where Wrye Bash would not completely uninstall on x64 platforms
- Fixed an issue where resources and start menu shortcuts would not install at all
- Fixed an issue where the start menu shortcut would be installed to the wrong folder when Wrye Bash was installed for Nehrim
- Fixed an issue where Wrye Bash could not be launched from the final page of the installer for TES5, SSE, and FO4