### PR TITLE
Update to RecordHeader

### DIFF
--- a/Mopy/bash/bish.py
+++ b/Mopy/bash/bish.py
@@ -736,7 +736,7 @@ def getIds(fileName=None):
             if str0 in ('CELL','WRLD'):
                 # header[1]-24,1 20 for Oblivion, 24 for others.
                 # There needs to be a global for this.
-                # ins.seek(size-header.__class__.size,1)
+                # ins.seek(size-header.__class__.rec_header_size,1)
                 # ModReader.recHeader.size
                 ins.seek(size-20,1)
         elif type != 'GRUP':
@@ -750,7 +750,7 @@ def getIds(fileName=None):
                     break
                 # header[1]-24,1 20 for Oblivion, 24 for others.
                 # There needs to be a global for this.
-                # ins.seek(size-header.__class__.size,1)
+                # ins.seek(size-header.__class__.rec_header_size,1)
                 # ModReader.recHeader.size
                 ins.seek(size,1)
             records.append((fid,eid))

--- a/Mopy/bash/bosh/mods_metadata.py
+++ b/Mopy/bash/bosh/mods_metadata.py
@@ -963,7 +963,7 @@ class ModCleaner:
                             if header.groupType != 0:
                                 pass
                             elif header.label not in ('CELL','WRLD'):
-                                copy(size-header.__class__.size)
+                                copy(size-header.__class__.rec_header_size)
                         else:
                             if doUDR and header.flags1 & 0x20 and type in {
                                 'ACRE',               #--Oblivion only
@@ -971,7 +971,7 @@ class ModCleaner:
                                 'NAVM','PGRE','PHZD', #--Skyrim only
                                 }:
                                 header.flags1 = (header.flags1 & ~0x20) | 0x1000
-                                out.seek(-header.__class__.size,1)
+                                out.seek(-header.__class__.rec_header_size,1)
                                 out.write(header.pack())
                                 changed = True
                             if doFog and type == 'CELL':
@@ -1043,12 +1043,12 @@ class NvidiaFogFixer:
                     header = ins.unpackRecHeader()
                     type,size = header.recType,header.size
                     #(type,size,str0,fid,uint2) = ins.unpackRecHeader()
-                    copyPrev(header.__class__.size)
+                    copyPrev(header.__class__.rec_header_size)
                     if type == 'GRUP':
                         if header.groupType != 0: #--Ignore sub-groups
                             pass
                         elif header.label not in ('CELL','WRLD'):
-                            copy(size-header.__class__.size)
+                            copy(size-header.__class__.rec_header_size)
                     #--Handle cells
                     elif type == 'CELL':
                         nextRecord = ins.tell() + size
@@ -1105,13 +1105,13 @@ class ModDetails:
                 if recType == 'GRUP':
                     # FIXME(ut): monkey patch for fallout QUST GRUP
                     if bush.game.fsName == u'Fallout4' and header.groupType == 10:
-                        ins.seek(rec_siz - header.__class__.size, 1)
+                        ins.seek(rec_siz - header.__class__.rec_header_size, 1)
                         continue
                     label = header.label
                     progress(1.0*ins.tell()/modInfo.size,_(u"Scanning: ")+label)
                     records = group_records.setdefault(label,[])
                     if label in ('CELL', 'WRLD', 'DIAL'): # skip these groups
-                        ins.seek(rec_siz - header.__class__.size, 1)
+                        ins.seek(rec_siz - header.__class__.rec_header_size, 1)
                 elif recType != 'GRUP':
                     eid = u''
                     nextRecord = ins.tell() + rec_siz

--- a/Mopy/bash/game/__init__.py
+++ b/Mopy/bash/game/__init__.py
@@ -221,24 +221,6 @@ class esp:
     #--Record Types: all recognized record types (not just the top types)
     recordTypes = set(topTypes + 'GRUP,TES4'.split(','))
 
-class RecordHeader(brec.BaseRecordHeader):
-    size = 20 # Size in bytes of a record header
-
-    def __init__(self,recType='TES4',size=0,arg1=0,arg2=0,arg3=0,*extra):
-        self.recType = recType
-        self.size = size
-        # Do some conditional stuff, commonly different variable names
-		# if this is a GRUP header or an actual record
-
-    @staticmethod
-    def unpack(ins):
-        """Returns a RecordHeader object by reading the input stream."""
-        pass
-
-    def pack(self):
-        """Returns the record header packed into a string for writing to file."""
-        pass
-
 #--The pickle file for this game.  Holds encoded GMST IDs from the big list below
 pklfile = ur'bash\db\*GAMENAME*_ids.pkl'
 
@@ -266,7 +248,6 @@ def init():
     # statement - in other words, nothing happens.  This means any lines that
     # affect outside modules must do so within this function, which will be
     # called instead of 'reload'
-    brec.ModReader.recHeader = RecordHeader
 
     #--Record Types
     brec.MreRecord.type_class = dict((x.classType,x) for x in  (

--- a/Mopy/bash/game/skyrim/__init__.py
+++ b/Mopy/bash/game/skyrim/__init__.py
@@ -392,62 +392,6 @@ class esp:
             ','))
 
 #--Mod I/O
-class RecordHeader(BaseRecordHeader):
-    size = 24
-
-    def __init__(self,recType='TES4',size=0,arg1=0,arg2=0,arg3=0,extra=0):
-        self.recType = recType
-        self.size = size
-        if recType == 'GRUP':
-            self.label = arg1
-            self.groupType = arg2
-            self.stamp = arg3
-        else:
-            self.flags1 = arg1
-            self.fid = arg2
-            self.flags2 = arg3
-        self.extra = extra
-
-    @staticmethod
-    def unpack(ins):
-        """Returns a RecordHeader object by reading the input stream."""
-        rec_type,size,uint0,uint1,uint2,uint3 = ins.unpack('=4s5I',24,'REC_HEADER')
-        #--Bad type?
-        if rec_type not in esp.recordTypes:
-            raise ModError(ins.inName,u'Bad header type: '+repr(rec_type))
-        #--Record
-        if rec_type != 'GRUP':
-            pass
-        #--Top Group
-        elif uint1 == 0: #groupType == 0 (Top Type)
-            str0 = struct.pack('I',uint0)
-            if str0 in esp.topTypes:
-                uint0 = str0
-            elif str0 in esp.topIgTypes:
-                uint0 = esp.topIgTypes[str0]
-            else:
-                raise ModError(ins.inName,u'Bad Top GRUP type: '+repr(str0))
-        #--Other groups
-        return RecordHeader(rec_type,size,uint0,uint1,uint2,uint3)
-
-    def pack(self):
-        """Return the record header packed into a bitstream to be written to file."""
-        if self.recType == 'GRUP':
-            if isinstance(self.label,str):
-                return struct.pack('=4sI4sIII',self.recType,self.size,
-                                   self.label,self.groupType,self.stamp,
-                                   self.extra)
-            elif isinstance(self.label,tuple):
-                return struct.pack('=4sIhhIII',self.recType,self.size,
-                                   self.label[0],self.label[1],self.groupType,
-                                   self.stamp,self.extra)
-            else:
-                return struct.pack('=4s5I',self.recType,self.size,self.label,
-                                   self.groupType,self.stamp,self.extra)
-        else:
-            return struct.pack('=4s5I',self.recType,self.size,self.flags1,
-                               self.fid,self.flags2,self.extra)
-
 #------------------------------------------------------------------------------
 # Unused records, they have empty GRUP in skyrim.esm---------------------------
 # CLDC ------------------------------------------------------------------------
@@ -513,7 +457,6 @@ def init():
     # statement - in otherwords, nothing happens.  This means any lines that
     # affect outside modules must do so within this function, which will be
     # called instead of 'reload'
-    brec.ModReader.recHeader = RecordHeader
 
     #--Record Types
     brec.MreRecord.type_class = dict((x.classType,x) for x in (

--- a/Mopy/bash/game/skyrimse/__init__.py
+++ b/Mopy/bash/game/skyrimse/__init__.py
@@ -274,7 +274,7 @@ def init():
     # statement - in otherwords, nothing happens.  This means any lines that
     # affect outside modules must do so within this function, which will be
     # called instead of 'reload'
-    brec.ModReader.recHeader = RecordHeader
+    # brec.ModReader.recHeader = RecordHeader
 
     #--Record Types
     brec.MreRecord.type_class = dict((x.classType,x) for x in (

--- a/Mopy/bash/parsers.py
+++ b/Mopy/bash/parsers.py
@@ -4009,7 +4009,7 @@ class ModFile(object):
                         self.tops[label].load(ins, unpack and (topClass != MobBase))
                     else:
                         self.topsSkipped.add(label)
-                        insSeek(size-header.__class__.size,1,type + '.' + label)
+                        insSeek(size-header.__class__.rec_header_size,1,type + '.' + label)
                 except:
                     print u'Error in',self.fileInfo.name.s
                     deprint(u' ',traceback=True)

--- a/Mopy/bash/record_groups.py
+++ b/Mopy/bash/record_groups.py
@@ -63,11 +63,11 @@ class MobBase(object):
         if self.debug: print u'GRUP load:',self.label
         #--Read, but don't analyze.
         if not unpack:
-            self.data = ins.read(self.size - self.header.__class__.size, type(self))
+            self.data = ins.read(self.size - self.header.__class__.rec_header_size, type(self))
         #--Analyze ins.
         elif ins is not None:
             self.loadData(ins,
-                          ins.tell() + self.size - self.header.__class__.size)
+                          ins.tell() + self.size - self.header.__class__.rec_header_size)
         #--Analyze internal buffer.
         else:
             with self.getReader() as reader:
@@ -189,7 +189,7 @@ class MobObjects(MobBase):
         if not self.changed:
             return self.size
         else:
-            hsize = ModReader.recHeader.size #@UndefinedVariable
+            hsize = ModReader.recHeader.rec_header_size #@UndefinedVariable
             return hsize + sum(
                 (hsize + record.getSize()) for record in self.records)
 
@@ -202,7 +202,7 @@ class MobObjects(MobBase):
             out.write(self.data)
         else:
             size = self.getSize()
-            if size == ModReader.recHeader.size: return #@UndefinedVariable
+            if size == ModReader.recHeader.rec_header_size: return #@UndefinedVariable
             # noinspection PyArgumentList
             out.write(ModReader.recHeader('GRUP',size,self.label,0,
                                           self.stamp).pack())
@@ -311,10 +311,10 @@ class MobDials(MobObjects):
                         infoClass = loadGetRecClass('INFO')
                         if infoClass:
                             recordLoadInfos(ins, ins.tell() + size -
-                                            header.__class__.size,
+                                            header.__class__.rec_header_size,
                                             infoClass)
                         else:
-                            ins.seek(ins.tell() + size - header.__class__.size)
+                            ins.seek(ins.tell() + size - header.__class__.rec_header_size)
                     except AttributeError:
                         ModError(self.inName, u'Malformed Plugin: Exterior '
                                  u'CELL subblock before worldspace GRUP')
@@ -332,7 +332,7 @@ class MobDials(MobObjects):
         """Returns size of records plus group and record headers."""
         if not self.changed:
             return self.size
-        hsize = ModReader.recHeader.size #@UndefinedVariable
+        hsize = ModReader.recHeader.rec_header_size #@UndefinedVariable
         size = hsize
         for record in self.records:
             size += hsize + record.getSize()
@@ -415,7 +415,7 @@ class MobCell(MobBase):
 
     def getSize(self):
         """Returns size (including size of any group headers)."""
-        return ModReader.recHeader.size + self.cell.getSize() + \
+        return ModReader.recHeader.rec_header_size + self.cell.getSize() + \
                self.getChildrenSize()  #@UndefinedVariable
 
     def getChildrenSize(self):
@@ -423,35 +423,35 @@ class MobCell(MobBase):
         does not include the cell itself."""
         size = self.getPersistentSize() + self.getTempSize() + \
                self.getDistantSize()
-        return size + ModReader.recHeader.size * bool(
+        return size + ModReader.recHeader.rec_header_size * bool(
             size)  #@UndefinedVariable
 
     def getPersistentSize(self):
         """Returns size of all persistent children, including the persistent
         children group."""
-        size = sum(ModReader.recHeader.size + x.getSize() for x in
+        size = sum(ModReader.recHeader.rec_header_size + x.getSize() for x in
                    self.persistent)  #@UndefinedVariable
-        return size + ModReader.recHeader.size * bool(
+        return size + ModReader.recHeader.rec_header_size * bool(
             size)  #@UndefinedVariable
 
     def getTempSize(self):
         """Returns size of all temporary children, including the temporary
         children group."""
-        size = sum(ModReader.recHeader.size + x.getSize() for x in
+        size = sum(ModReader.recHeader.rec_header_size + x.getSize() for x in
                    self.temp)  #@UndefinedVariable
-        if self.pgrd: size += ModReader.recHeader.size + self.pgrd.getSize()
+        if self.pgrd: size += ModReader.recHeader.rec_header_size + self.pgrd.getSize()
         #@UndefinedVariable
-        if self.land: size += ModReader.recHeader.size + self.land.getSize()
+        if self.land: size += ModReader.recHeader.rec_header_size + self.land.getSize()
         #@UndefinedVariable
-        return size + ModReader.recHeader.size * bool(
+        return size + ModReader.recHeader.rec_header_size * bool(
             size)  #@UndefinedVariable
 
     def getDistantSize(self):
         """Returns size of all distant children, including the distant
         children group."""
-        size = sum(ModReader.recHeader.size + x.getSize() for x in
+        size = sum(ModReader.recHeader.rec_header_size + x.getSize() for x in
                    self.distant)  #@UndefinedVariable
-        return size + ModReader.recHeader.size * bool(
+        return size + ModReader.recHeader.rec_header_size * bool(
             size)  #@UndefinedVariable
 
     def getNumRecords(self,includeGroups=True):
@@ -629,20 +629,20 @@ class MobCells(MobBase):
         bsbCellBlocks.sort(key = lambda y: y[1].cell.fid)
         bsbCellBlocks.sort(key = itemgetter(0))
         bsb_size = {}
-        totalSize = ModReader.recHeader.size #@UndefinedVariable
+        totalSize = ModReader.recHeader.rec_header_size #@UndefinedVariable
         bsb_setDefault = bsb_size.setdefault
         for bsb,cellBlock in bsbCellBlocks:
             cellBlockSize = cellBlock.getSize()
             totalSize += cellBlockSize
             bsb0 = (bsb[0],None) #--Block group
-            bsb_setDefault(bsb0,ModReader.recHeader.size) #@UndefinedVariable
+            bsb_setDefault(bsb0,ModReader.recHeader.rec_header_size) #@UndefinedVariable
             if bsb_setDefault(bsb,
-                              ModReader.recHeader.size) == \
-                    ModReader.recHeader.size:  #@UndefinedVariable
-                bsb_size[bsb0] += ModReader.recHeader.size  #@UndefinedVariable
+                              ModReader.recHeader.rec_header_size) == \
+                    ModReader.recHeader.rec_header_size:  #@UndefinedVariable
+                bsb_size[bsb0] += ModReader.recHeader.rec_header_size  #@UndefinedVariable
             bsb_size[bsb] += cellBlockSize
             bsb_size[bsb0] += cellBlockSize
-        totalSize += ModReader.recHeader.size * len(
+        totalSize += ModReader.recHeader.rec_header_size * len(
             bsb_size)  #@UndefinedVariable
         return totalSize,bsb_size,bsbCellBlocks
 
@@ -746,7 +746,7 @@ class MobICells(MobCells):
             elif recType == 'GRUP':
                 size,groupFid,groupType = header.size,header.label, \
                                           header.groupType
-                delta = size - header.__class__.size
+                delta = size - header.__class__.rec_header_size
                 if groupType == 2: # Block number
                     endBlockPos = insTell() + delta
                 elif groupType == 3: # Sub-block number
@@ -828,7 +828,7 @@ class MobWorld(MobCells):
             #--Get record info and handle it
             header = insRecHeader()
             recType,size = header.recType,header.size
-            delta = size - header.__class__.size
+            delta = size - header.__class__.rec_header_size
             recClass = cellGet(recType)
             if recType == 'ROAD':
                 if not recClass: insSeek(size,1)
@@ -916,7 +916,7 @@ class MobWorld(MobCells):
     def dump(self,out):
         """Dumps group header and then records.  Returns the total size of
         the world block."""
-        worldSize = self.world.getSize() + ModReader.recHeader.size
+        worldSize = self.world.getSize() + ModReader.recHeader.rec_header_size
         #@UndefinedVariable
         self.world.dump(out)
         if not self.changed:
@@ -926,7 +926,7 @@ class MobWorld(MobCells):
         elif self.cellBlocks or self.road or self.worldCellBlock:
             (totalSize, bsb_size, blocks) = self.getBsbSizes()
             if self.road:
-                totalSize += self.road.getSize() + ModReader.recHeader.size
+                totalSize += self.road.getSize() + ModReader.recHeader.rec_header_size
                 #@UndefinedVariable
             if self.worldCellBlock:
                 totalSize += self.worldCellBlock.getSize()
@@ -1038,7 +1038,7 @@ class MobWorlds(MobBase):
                     #raise ModError(ins.inName,'Extra subgroup %d in WRLD
                     # group.' % groupType)
                     #--Orphaned world records. Skip over.
-                    insSeek(header.size - header.__class__.size,1)
+                    insSeek(header.size - header.__class__.rec_header_size,1)
                     self.orphansSkipped += 1
                     continue
                 if groupFid != world.fid:
@@ -1056,7 +1056,7 @@ class MobWorlds(MobBase):
 
     def getSize(self):
         """Returns size (including size of any group headers)."""
-        return ModReader.recHeader.size + sum(
+        return ModReader.recHeader.rec_header_size + sum(
             x.getSize() for x in self.worldBlocks)  #@UndefinedVariable
 
     def dump(self,out):
@@ -1070,7 +1070,7 @@ class MobWorlds(MobBase):
             # noinspection PyArgumentList
             header = ModReader.recHeader('GRUP',0,self.label,0,self.stamp)
             out.write(header.pack())
-            totalSize = header.__class__.size + sum(
+            totalSize = header.__class__.rec_header_size + sum(
                 x.dump(out) for x in self.worldBlocks)
             out.seek(worldHeaderPos + 4)
             out.pack('I', totalSize)


### PR DESCRIPTION
Since it's at least of some interest and eliminates duplicate code I will make a proper pull request.

 - Moved RecordHeader to Brec
 - RecordHeader in ``__init__.py`` is no longer needed.
 - The original RecordHeader class from ``__init__.py`` used size as part of the class. This indicated the size of the record header. 20 for Oblivion and 24 for all other games.  The size variable had been moved to a class method and renamed to more descriptive rec_header_size.