### PR TITLE
Allow keyword Bash identifier to be mixed case…

### DIFF
--- a/Mopy/bash/bosh/__init__.py
+++ b/Mopy/bash/bosh/__init__.py
@@ -699,7 +699,7 @@ class ModInfo(FileInfo):
     def getBashTagsDesc(self):
         """Returns any Bash flag keys."""
         description = self.header.description or u''
-        maBashKeys = re.search(u'{{ *BASH *:([^}]+)}}',description,flags=re.U)
+        maBashKeys = re.search(u'{{ *BASH *:([^}]+)}}',description,flags=re.U|re.I)
         if not maBashKeys:
             return set()
         else:


### PR DESCRIPTION
...e.g. {{Bash: xxx}}

Skyrim SE's mod file AnotherSortingMod_2017-SSE.esp from the mod https://www.nexusmods.com/skyrimspecialedition/mods/10 has {{Bash:Names,Stats}} in it's description. This is the first mod I've noticed that doesn't observe the uppercase BASH identifier keyword. This may be the beginning of a trend. Unknown.

Mator Smash accepts the mixed case Bash keyword. If WB only recognizes uppercase BASH and other tools like Mator Smash accept mixed case, WB risks being viewed as unnecessarily rigged and not accepting of changing uses.

WB already is forgiving about spaces within the curly braces. This change just extends that forgivingness to the keyword identifier.

This is a very small fix that makes WB forgiving and accepting of more mods. I don't see any undesirable
side effects.