### PR TITLE
Fix Duplicate Records In Stats Parsing

### DIFF
--- a/Mopy/bash/game/skyrim/constants.py
+++ b/Mopy/bash/game/skyrim/constants.py
@@ -17070,7 +17070,7 @@ statsTypes = {
         'SLGM':('eid', 'weight', 'value'),
         'WEAP':('eid', 'weight', 'value', 'damage', 'speed', 'reach',
                 'enchantPoints', 'stagger', 'critDamage','criticalMultiplier',
-                'criticalEffect',),
+            ),
     }
 statsHeaders = (
     #--Alch
@@ -17117,7 +17117,8 @@ statsHeaders = (
     (u'WEAP',
         (u'"' + u'","'.join((_(u'Type'),_(u'Mod Name'),_(u'ObjectIndex'),
         _(u'Editor Id'),_(u'Weight'),_(u'Value'),_(u'Damage'),
-        _(u'Speed'),_(u'Reach'),_(u'EPoints'))) + u'"\n')),
+        _(u'Speed'),_(u'Reach'),_(u'EPoints'),_(u'Stagger'),
+        _(u'CritDamage'),_(u'criticalMultiplier'))) + u'"\n')),
 )
 
 #------------------------------------------------------------------------------

--- a/Mopy/bash/parsers.py
+++ b/Mopy/bash/parsers.py
@@ -1383,7 +1383,7 @@ class ItemStats:
         self.class_attrs = bush.game_mod.statsTypes
         self.class_fid_attr_value = {}
         self.aliases = aliases or {} #--For aliasing mod names
-        if bush.game.fsName == u'Skyrim':
+        if bush.game.fsName in (u'Skyrim', u'Skyrim Special Edition') :
             self.attr_type = {'eid':self.sstr,
                               'weight':self.sfloat,
                               'value':self.sint,
@@ -1395,8 +1395,7 @@ class ItemStats:
                               'stagger':self.sfloat,
                               'enchantPoints':self.sint,
                               'critDamage':self.sint,
-                              'criticalMultiplier':self.sfloat,
-                              'criticalEffect':self.sint,}
+                              'criticalMultiplier':self.sfloat,}
         elif bush.game.fsName in (u'FalloutNV', u'Fallout3'):
             self.attr_type = {'eid':self.sstr,
                               'weight':self.sfloat,


### PR DESCRIPTION
'criticalEffect': (bolt.Path(u'Skyrim.esm'), 0)

Critical effect is a FormID but was being parsed as an int.
Which meant the comparision for a change always gave a result of true.
When led to a high number of ITM when using the stats patcher.